### PR TITLE
Refactor queue status

### DIFF
--- a/JMMContracts/Contract_ServerStatus.cs
+++ b/JMMContracts/Contract_ServerStatus.cs
@@ -3,11 +3,17 @@
     public class Contract_ServerStatus
     {
         public int HashQueueCount { get; set; }
-        public string HashQueueState { get; set; }
+        public string HashQueueState { get; set; }  //Deprecated since 3.6.0.0
+        public int HashQueueStateId { get; set; }
+        public string[] HashQueueStateParams { get; set; }
         public int GeneralQueueCount { get; set; }
-        public string GeneralQueueState { get; set; }
+        public string GeneralQueueState { get; set; } //Deprecated since 3.6.0.0
+        public int GeneralQueueStateId { get; set; }
+        public string[] GeneralQueueStateParams { get; set; }
         public int ImagesQueueCount { get; set; }
-        public string ImagesQueueState { get; set; }
+        public string ImagesQueueState { get; set; } //Deprecated since 3.6.0.0
+        public int ImagesQueueStateId { get; set; }
+        public string[] ImagesQueueStateParams { get; set; }
         public bool IsBanned { get; set; }
         public string BanReason { get; set; }
         public string BanOrigin { get; set; }

--- a/JMMServer/Commands/AniDB/CommandRequest_AddFileToMyList.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_AddFileToMyList.cs
@@ -21,16 +21,14 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
                 if (vid != null)
-                    return string.Format(JMMServer.Properties.Resources.AniDB_MyListAdd, vid.FullServerPath);
+                    return new QueueStateStruct() { queueState=QueueStateEnum.AniDB_MyListAdd, extraParams = new string[] { vid.FullServerPath  } };
                 else
-                    return string.Format(JMMServer.Properties.Resources.AniDB_MyListAdd, Hash);
+                    return new QueueStateStruct() { queueState = QueueStateEnum.AniDB_MyListAdd, extraParams = new string[] { Hash } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_DeleteFileFromMyList.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_DeleteFileFromMyList.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.AniDB_MyListDelete, Hash, FileID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.AniDB_MyListDelete, extraParams = new string[] { Hash, FileID.ToString() } };               
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetAniDBTitles.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetAniDBTitles.cs
@@ -20,13 +20,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority10; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.AniDB_GetTitles);
+                return new QueueStateStruct() { queueState = QueueStateEnum.AniDB_GetTitles, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetAnimeHTTP.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetAnimeHTTP.cs
@@ -19,13 +19,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority2; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_AnimeInfo, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.AnimeInfo, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetCalendar.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetCalendar.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority7; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_GetCalendar);
+                return new QueueStateStruct() { queueState = QueueStateEnum.GetCalendar, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetEpisode.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetEpisode.cs
@@ -19,13 +19,11 @@ namespace JMMServer.Commands.AniDB
             get { return CommandRequestPriority.Priority4; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_GetEpisodeList, EpisodeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.GetEpisodeList, extraParams = new string[] { EpisodeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetFile.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetFile.cs
@@ -23,16 +23,14 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority3; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
                 if (vlocal != null)
-                    return string.Format(JMMServer.Properties.Resources.Command_GetFileInfo, vlocal.FullServerPath);
+                    return new QueueStateStruct() { queueState = QueueStateEnum.GetFileInfo, extraParams = new string[] { vlocal.FullServerPath } };
                 else
-                    return string.Format(JMMServer.Properties.Resources.Command_GetFileInfo, VideoLocalID);
+                    return new QueueStateStruct() { queueState = QueueStateEnum.GetFileInfo, extraParams = new string[] { VideoLocalID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetReleaseGroup.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetReleaseGroup.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_GetReleaseInfo, GroupID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.GetReleaseInfo, extraParams = new string[] { GroupID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetReleaseGroupStatus.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetReleaseGroupStatus.cs
@@ -20,13 +20,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority5; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_GetReleaseGroup, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.GetReleaseGroup, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetReviews.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetReviews.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_GetReviewInfo, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.GetReviewInfo, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_GetUpdated.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetUpdated.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority4; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_GetUpdatedAnime);
+                return new QueueStateStruct() { queueState = QueueStateEnum.GetUpdatedAnime, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_SyncMyList.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_SyncMyList.cs
@@ -20,13 +20,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority6; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SyncMyList);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SyncMyList, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_SyncMyVotes.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_SyncMyVotes.cs
@@ -19,13 +19,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority6; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Actions_SyncVotes);
+                return new QueueStateStruct() { queueState = QueueStateEnum.Actions_SyncVotes, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_UpdateMyListFileStatus.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_UpdateMyListFileStatus.cs
@@ -22,13 +22,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_UpdateMyListInfo, FullFileName);
+                return new QueueStateStruct() { queueState = QueueStateEnum.UpdateMyListInfo, extraParams = new string[] { FullFileName } };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_UpdateMylistStats.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_UpdateMylistStats.cs
@@ -17,13 +17,11 @@ namespace JMMServer.Commands.AniDB
             get { return CommandRequestPriority.Priority10; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_UpdateMyListStats);
+                return new QueueStateStruct() { queueState = QueueStateEnum.UpdateMyListStats, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/AniDB/CommandRequest_VoteAnime.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_VoteAnime.cs
@@ -19,13 +19,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_VoteAnime, AnimeID, VoteValue);
+                return new QueueStateStruct() { queueState = QueueStateEnum.VoteAnime, extraParams = new string[] { AnimeID.ToString(), VoteValue.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/Azure/CommandRequest_Azure_SendAnimeFull.cs
+++ b/JMMServer/Commands/Azure/CommandRequest_Azure_SendAnimeFull.cs
@@ -17,13 +17,11 @@ namespace JMMServer.Commands.Azure
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SendAnimeFull, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SendAnimeFull, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/Azure/CommandRequest_Azure_SendAnimeTitle.cs
+++ b/JMMServer/Commands/Azure/CommandRequest_Azure_SendAnimeTitle.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands.Azure
             get { return CommandRequestPriority.Priority11; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SendAnimeTitle, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SendAnimeTitle, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/Azure/CommandRequest_Azure_SendAnimeXML.cs
+++ b/JMMServer/Commands/Azure/CommandRequest_Azure_SendAnimeXML.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands.Azure
             get { return CommandRequestPriority.Priority10; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SendAnimeAzure, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SendAnimeAzure, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/Azure/CommandRequest_Azure_SendUserInfo.cs
+++ b/JMMServer/Commands/Azure/CommandRequest_Azure_SendUserInfo.cs
@@ -16,13 +16,11 @@ namespace JMMServer.Commands.Azure
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return JMMServer.Properties.Resources.Command_SendAnonymousData;
+                return new QueueStateStruct() { queueState = QueueStateEnum.SendAnonymousData, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/CommandHelper.cs
+++ b/JMMServer/Commands/CommandHelper.cs
@@ -7,7 +7,7 @@ using JMMServer.Entities;
 namespace JMMServer.Commands
 {
     public enum QueueStateEnum {
-        AnimeInfo, DeleteError, DownloadImage, DownloadMalWatched, DownloadTvDBImages, FileInfo, GetCalendar, GetEpisodeList, GetFileInfo, GetReleaseGroup,
+        AnimeInfo=1, DeleteError, DownloadImage, DownloadMalWatched, DownloadTvDBImages, FileInfo, GetCalendar, GetEpisodeList, GetFileInfo, GetReleaseGroup,
         GetReleaseInfo, GetReviewInfo, GettingTvDB, GetUpdatedAnime, HashingFile, Idle, Paused, Queued, ReadingMedia, Refresh, SearchMal, SearchTMDb, SearchTrakt,
         SearchTvDB, SendAnimeAzure, SendAnimeFull, SendAnimeTitle, SendAnonymousData, StartingGeneral, StartingHasher, StartingImages, SyncMyList, SyncTrakt,
         SyncTraktEpisodes, SyncTraktSeries, SyncVotes, TraktAddHistory, UpdateMALWatched, UpdateMyListInfo, UpdateMyListStats, UpdateTrakt, UpdateTraktData, UploadMALWatched,

--- a/JMMServer/Commands/CommandHelper.cs
+++ b/JMMServer/Commands/CommandHelper.cs
@@ -6,6 +6,21 @@ using JMMServer.Entities;
 
 namespace JMMServer.Commands
 {
+    public enum QueueStateEnum {
+        AnimeInfo, DeleteError, DownloadImage, DownloadMalWatched, DownloadTvDBImages, FileInfo, GetCalendar, GetEpisodeList, GetFileInfo, GetReleaseGroup,
+        GetReleaseInfo, GetReviewInfo, GettingTvDB, GetUpdatedAnime, HashingFile, Idle, Paused, Queued, ReadingMedia, Refresh, SearchMal, SearchTMDb, SearchTrakt,
+        SearchTvDB, SendAnimeAzure, SendAnimeFull, SendAnimeTitle, SendAnonymousData, StartingGeneral, StartingHasher, StartingImages, SyncMyList, SyncTrakt,
+        SyncTraktEpisodes, SyncTraktSeries, SyncVotes, TraktAddHistory, UpdateMALWatched, UpdateMyListInfo, UpdateMyListStats, UpdateTrakt, UpdateTraktData, UploadMALWatched,
+        VoteAnime, WebCacheDeleteXRefAniDBMAL, WebCacheDeleteXRefAniDBOther, WebCacheDeleteXRefAniDBTrakt, WebCacheDeleteXRefAniDBTvDB, WebCacheDeleteXRefFileEpisode, WebCacheSendXRefAniDBMAL,
+        WebCacheSendXRefAniDBOther, WebCacheSendXRefAniDBTrakt, WebCacheSendXRefAniDBTvDB, WebCacheSendXRefFileEpisode, AniDB_MyListAdd, AniDB_MyListDelete, AniDB_GetTitles, Actions_SyncVotes
+    };
+
+    public struct QueueStateStruct
+    {
+        public QueueStateEnum queueState;
+        public string[] extraParams;
+    }
+
     public class CommandHelper
     {
         // List of Default priorities for commands

--- a/JMMServer/Commands/CommandHelper.cs
+++ b/JMMServer/Commands/CommandHelper.cs
@@ -19,6 +19,135 @@ namespace JMMServer.Commands
     {
         public QueueStateEnum queueState;
         public string[] extraParams;
+        public string formatMessage()
+        {
+            string formatString = getFormatString(queueState);
+            return string.Format(formatString, extraParams);
+        }
+        private string getFormatString(QueueStateEnum id)
+        {
+            switch (id) {
+                case QueueStateEnum.AnimeInfo:
+                    return JMMServer.Properties.Resources.Command_AnimeInfo;
+                case QueueStateEnum.DeleteError:
+                    return JMMServer.Properties.Resources.Command_DeleteError;
+                case QueueStateEnum.DownloadImage:
+                    return JMMServer.Properties.Resources.Command_DownloadImage;
+                case QueueStateEnum.DownloadMalWatched:
+                    return JMMServer.Properties.Resources.Command_DownloadMalWatched;
+                case QueueStateEnum.DownloadTvDBImages:
+                    return JMMServer.Properties.Resources.Command_DownloadTvDBImages;
+                case QueueStateEnum.FileInfo:
+                    return JMMServer.Properties.Resources.Command_FileInfo;
+                case QueueStateEnum.GetCalendar:
+                    return JMMServer.Properties.Resources.Command_GetCalendar;
+                case QueueStateEnum.GetEpisodeList:
+                    return JMMServer.Properties.Resources.Command_GetEpisodeList;
+                case QueueStateEnum.GetFileInfo:
+                    return JMMServer.Properties.Resources.Command_GetFileInfo;
+                case QueueStateEnum.GetReleaseGroup:
+                    return JMMServer.Properties.Resources.Command_GetReleaseGroup;
+                case QueueStateEnum.GetReleaseInfo:
+                    return JMMServer.Properties.Resources.Command_GetReleaseInfo;
+                case QueueStateEnum.GetReviewInfo:
+                    return JMMServer.Properties.Resources.Command_GetReviewInfo;
+                case QueueStateEnum.GettingTvDB:
+                    return JMMServer.Properties.Resources.Command_GettingTvDB;
+                case QueueStateEnum.GetUpdatedAnime:
+                    return JMMServer.Properties.Resources.Command_GetUpdatedAnime;
+                case QueueStateEnum.HashingFile:
+                    return JMMServer.Properties.Resources.Command_HashingFile;
+                case QueueStateEnum.Idle:
+                    return JMMServer.Properties.Resources.Command_Idle;
+                case QueueStateEnum.Paused:
+                    return JMMServer.Properties.Resources.Command_Paused;
+                case QueueStateEnum.Queued:
+                    return JMMServer.Properties.Resources.Command_Queued;
+                case QueueStateEnum.ReadingMedia:
+                    return JMMServer.Properties.Resources.Command_ReadingMedia;
+                case QueueStateEnum.Refresh:
+                    return JMMServer.Properties.Resources.Command_Refresh;
+                case QueueStateEnum.SearchMal:
+                    return JMMServer.Properties.Resources.Command_SearchMal;
+                case QueueStateEnum.SearchTMDb:
+                    return JMMServer.Properties.Resources.Command_SearchTMDb;
+                case QueueStateEnum.SearchTrakt:
+                    return JMMServer.Properties.Resources.Command_SearchTrakt;
+                case QueueStateEnum.SearchTvDB:
+                    return JMMServer.Properties.Resources.Command_SearchTvDB;
+                case QueueStateEnum.SendAnimeAzure:
+                    return JMMServer.Properties.Resources.Command_SendAnimeAzure;
+                case QueueStateEnum.SendAnimeFull:
+                    return JMMServer.Properties.Resources.Command_SendAnimeFull;
+                case QueueStateEnum.SendAnimeTitle:
+                    return JMMServer.Properties.Resources.Command_SendAnimeTitle;
+                case QueueStateEnum.SendAnonymousData:
+                    return JMMServer.Properties.Resources.Command_SendAnonymousData;
+                case QueueStateEnum.StartingGeneral:
+                    return JMMServer.Properties.Resources.Command_StartingGeneral;
+                case QueueStateEnum.StartingHasher:
+                    return JMMServer.Properties.Resources.Command_StartingHasher;
+                case QueueStateEnum.StartingImages:
+                    return JMMServer.Properties.Resources.Command_StartingImages;
+                case QueueStateEnum.SyncMyList:
+                    return JMMServer.Properties.Resources.Command_SyncMyList;
+                case QueueStateEnum.SyncTrakt:
+                    return JMMServer.Properties.Resources.Command_SyncTrakt;
+                case QueueStateEnum.SyncTraktEpisodes:
+                    return JMMServer.Properties.Resources.Command_SyncTraktEpisodes;
+                case QueueStateEnum.SyncTraktSeries:
+                    return JMMServer.Properties.Resources.Command_SyncTraktSeries;
+                case QueueStateEnum.SyncVotes:
+                    return JMMServer.Properties.Resources.Command_SyncVotes;
+                case QueueStateEnum.TraktAddHistory:
+                    return JMMServer.Properties.Resources.Command_TraktAddHistory;
+                case QueueStateEnum.UpdateMALWatched:
+                    return JMMServer.Properties.Resources.Command_UpdateMALWatched;
+                case QueueStateEnum.UpdateMyListInfo:
+                    return JMMServer.Properties.Resources.Command_UpdateMyListInfo;
+                case QueueStateEnum.UpdateMyListStats:
+                    return JMMServer.Properties.Resources.Command_UpdateMyListStats;
+                case QueueStateEnum.UpdateTrakt:
+                    return JMMServer.Properties.Resources.Command_UpdateTrakt;
+                case QueueStateEnum.UpdateTraktData:
+                    return JMMServer.Properties.Resources.Command_UpdateTraktData;
+                case QueueStateEnum.UploadMALWatched:
+                    return JMMServer.Properties.Resources.Command_UploadMALWatched;
+                case QueueStateEnum.VoteAnime:
+                    return JMMServer.Properties.Resources.Command_VoteAnime;
+                case QueueStateEnum.WebCacheDeleteXRefAniDBMAL:
+                    return JMMServer.Properties.Resources.Command_WebCacheDeleteXRefAniDBMAL;
+                case QueueStateEnum.WebCacheDeleteXRefAniDBOther:
+                    return JMMServer.Properties.Resources.Command_WebCacheDeleteXRefAniDBOther;
+                case QueueStateEnum.WebCacheDeleteXRefAniDBTrakt:
+                    return JMMServer.Properties.Resources.Command_WebCacheDeleteXRefAniDBTrakt;
+                case QueueStateEnum.WebCacheDeleteXRefAniDBTvDB:
+                    return JMMServer.Properties.Resources.Command_WebCacheDeleteXRefAniDBTvDB;
+                case QueueStateEnum.WebCacheDeleteXRefFileEpisode:
+                    return JMMServer.Properties.Resources.Command_WebCacheDeleteXRefFileEpisode;
+                case QueueStateEnum.WebCacheSendXRefAniDBMAL:
+                    return JMMServer.Properties.Resources.Command_WebCacheSendXRefAniDBMAL;
+                case QueueStateEnum.WebCacheSendXRefAniDBOther:
+                    return JMMServer.Properties.Resources.Command_WebCacheSendXRefAniDBOther;
+                case QueueStateEnum.WebCacheSendXRefAniDBTrakt:
+                    return JMMServer.Properties.Resources.Command_WebCacheSendXRefAniDBTrakt;
+                case QueueStateEnum.WebCacheSendXRefAniDBTvDB:
+                    return JMMServer.Properties.Resources.Command_WebCacheSendXRefAniDBTvDB;
+                case QueueStateEnum.WebCacheSendXRefFileEpisode:
+                    return JMMServer.Properties.Resources.Command_WebCacheSendXRefFileEpisode;
+                case QueueStateEnum.AniDB_MyListAdd:
+                    return JMMServer.Properties.Resources.AniDB_MyListAdd;
+                case QueueStateEnum.AniDB_MyListDelete:
+                    return JMMServer.Properties.Resources.AniDB_MyListDelete;
+                case QueueStateEnum.AniDB_GetTitles:
+                    return JMMServer.Properties.Resources.AniDB_GetTitles;
+                case QueueStateEnum.Actions_SyncVotes:
+                    return JMMServer.Properties.Resources.Actions_SyncVotes;
+                default:
+                    throw new System.Exception("Unknown queue state format string"); ;
+            }
+
+        }
     }
 
     public class CommandHelper

--- a/JMMServer/Commands/CommandProcessorGeneral.cs
+++ b/JMMServer/Commands/CommandProcessorGeneral.cs
@@ -43,17 +43,15 @@ namespace JMMServer.Commands
             {
                 lock (lockPaused)
                 {
-                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
                     paused = value;
                     if (paused)
                     {
-                        QueueState = JMMServer.Properties.Resources.Command_Paused;
+                        QueueState = new QueueStateStruct { queueState = QueueStateEnum.Paused, extraParams = new string[0] };
                         pauseTime = DateTime.Now;
                     }
                     else
                     {
-                        QueueState = JMMServer.Properties.Resources.Command_Idle;
+                        QueueState = new QueueStateStruct { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
                         pauseTime = null;
                         JMMService.AnidbProcessor.IsBanned = false;
                         JMMService.AnidbProcessor.BanOrigin = "";
@@ -85,16 +83,14 @@ namespace JMMServer.Commands
             }
         }
 
-        private string queueState = JMMServer.Properties.Resources.Command_Idle;
+        private QueueStateStruct queueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
 
-        public string QueueState
+        public QueueStateStruct QueueState
         {
             get
             {
                 lock (lockQueueState)
                 {
-                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
                     return queueState;
                 }
             }
@@ -102,7 +98,7 @@ namespace JMMServer.Commands
             {
                 lock (lockQueueState)
                 {
-                    queueState = string.IsNullOrEmpty(value) ? JMMServer.Properties.Resources.Command_Idle : value;
+                    queueState = value;
                     OnQueueStateChangedEvent(new QueueStateEventArgs(queueState));
                 }
             }
@@ -129,7 +125,8 @@ namespace JMMServer.Commands
 
             processingCommands = false;
             //logger.Trace("Stopping command worker...");
-            QueueState = JMMServer.Properties.Resources.Command_Idle;
+            QueueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
+
             QueueCount = 0;
         }
 
@@ -139,7 +136,7 @@ namespace JMMServer.Commands
 
             processingCommands = true;
             //logger.Trace("Starting command worker...");
-            QueueState = JMMServer.Properties.Resources.Command_StartingGeneral;
+            QueueState = new QueueStateStruct() { queueState = QueueStateEnum.StartingGeneral, extraParams = new string[0] };
             this.workerCommands.RunWorkerAsync();
         }
 

--- a/JMMServer/Commands/CommandProcessorGeneral.cs
+++ b/JMMServer/Commands/CommandProcessorGeneral.cs
@@ -24,25 +24,9 @@ namespace JMMServer.Commands
 
         public event QueueCountChangedHandler OnQueueCountChangedEvent;
 
-        protected void OQueueCountChanged(QueueCountEventArgs ev)
-        {
-            if (OnQueueCountChangedEvent != null)
-            {
-                OnQueueCountChangedEvent(ev);
-            }
-        }
-
         public delegate void QueueStateChangedHandler(QueueStateEventArgs ev);
 
         public event QueueStateChangedHandler OnQueueStateChangedEvent;
-
-        protected void OQueueStateChanged(QueueStateEventArgs ev)
-        {
-            if (OnQueueStateChangedEvent != null)
-            {
-                OnQueueStateChangedEvent(ev);
-            }
-        }
 
         private bool paused = false;
 

--- a/JMMServer/Commands/CommandProcessorHasher.cs
+++ b/JMMServer/Commands/CommandProcessorHasher.cs
@@ -23,25 +23,9 @@ namespace JMMServer.Commands
 
         public event QueueCountChangedHandler OnQueueCountChangedEvent;
 
-        protected void OQueueCountChanged(QueueCountEventArgs ev)
-        {
-            if (OnQueueCountChangedEvent != null)
-            {
-                OnQueueCountChangedEvent(ev);
-            }
-        }
-
         public delegate void QueueStateChangedHandler(QueueStateEventArgs ev);
 
         public event QueueStateChangedHandler OnQueueStateChangedEvent;
-
-        protected void OQueueStateChanged(QueueStateEventArgs ev)
-        {
-            if (OnQueueStateChangedEvent != null)
-            {
-                OnQueueStateChangedEvent(ev);
-            }
-        }
 
         private bool paused = false;
 

--- a/JMMServer/Commands/CommandProcessorHasher.cs
+++ b/JMMServer/Commands/CommandProcessorHasher.cs
@@ -47,12 +47,12 @@ namespace JMMServer.Commands
                     paused = value;
                     if (paused)
                     {
-                        QueueState = JMMServer.Properties.Resources.Command_Paused;
+                        QueueState = new QueueStateStruct() { queueState = QueueStateEnum.Paused, extraParams = new string[0] };
                         pauseTime = DateTime.Now;
                     }
                     else
                     {
-                        QueueState = JMMServer.Properties.Resources.Command_Idle;
+                        QueueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
                         pauseTime = null;
                     }
 
@@ -83,15 +83,14 @@ namespace JMMServer.Commands
             }
         }
 
-        private string queueState = JMMServer.Properties.Resources.Command_Idle;
+        private QueueStateStruct queueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
 
-        public string QueueState
+        public QueueStateStruct QueueState
         {
             get
             {
                 lock (lockQueueState)
                 {
-                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
                     return queueState;
                 }
             }
@@ -99,7 +98,7 @@ namespace JMMServer.Commands
             {
                 lock (lockQueueState)
                 {
-                    queueState = string.IsNullOrEmpty(value) ? JMMServer.Properties.Resources.Command_Idle : value;
+                    queueState = value;
                     OnQueueStateChangedEvent(new QueueStateEventArgs(queueState));
                 }
             }
@@ -124,7 +123,7 @@ namespace JMMServer.Commands
 
             processingCommands = false;
             //logger.Trace("Stopping command worker (hasher)...");
-            QueueState = JMMServer.Properties.Resources.Command_Idle;
+            QueueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
             QueueCount = 0;
         }
 
@@ -134,7 +133,7 @@ namespace JMMServer.Commands
 
             processingCommands = true;
             //logger.Trace("Starting command worker (hasher)...");
-            QueueState = JMMServer.Properties.Resources.Command_StartingHasher;
+            QueueState = new QueueStateStruct() { queueState = QueueStateEnum.StartingHasher, extraParams = new string[0] };
             this.workerCommands.RunWorkerAsync();
         }
 

--- a/JMMServer/Commands/CommandProcessorImages.cs
+++ b/JMMServer/Commands/CommandProcessorImages.cs
@@ -47,12 +47,12 @@ namespace JMMServer.Commands
                     paused = value;
                     if (paused)
                     {
-                        QueueState = JMMServer.Properties.Resources.Command_Paused;
+                        QueueState = new QueueStateStruct() { queueState = QueueStateEnum.Paused, extraParams = new string[0] };
                         pauseTime = DateTime.Now;
                     }
                     else
                     {
-                        QueueState = JMMServer.Properties.Resources.Command_Idle;
+                        QueueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
                         pauseTime = null;
                     }
 
@@ -83,16 +83,14 @@ namespace JMMServer.Commands
             }
         }
 
-        private string queueState = JMMServer.Properties.Resources.Command_Idle;
+        private QueueStateStruct queueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
 
-        public string QueueState
+        public QueueStateStruct QueueState
         {
             get
             {
                 lock (lockQueueState)
                 {
-                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
                     return queueState;
                 }
             }
@@ -101,7 +99,7 @@ namespace JMMServer.Commands
                 lock (lockQueueState)
                 {
 
-                    queueState = string.IsNullOrEmpty(value) ? JMMServer.Properties.Resources.Command_Idle : value;
+                    queueState = value;
                     OnQueueStateChangedEvent(new QueueStateEventArgs(queueState));
                 }
             }
@@ -126,7 +124,7 @@ namespace JMMServer.Commands
 
             processingCommands = false;
             //logger.Trace("Stopping command worker (images)...");
-            QueueState = JMMServer.Properties.Resources.Command_Idle;
+            QueueState = new QueueStateStruct() { queueState = QueueStateEnum.Idle, extraParams = new string[0] };
             QueueCount = 0;
         }
 
@@ -136,7 +134,7 @@ namespace JMMServer.Commands
 
             processingCommands = true;
             //logger.Trace("Starting command worker (images)...");
-            QueueState = JMMServer.Properties.Resources.Command_StartingImages;
+            QueueState = new QueueStateStruct() { queueState = QueueStateEnum.StartingImages, extraParams = new string[0] };
             this.workerCommands.RunWorkerAsync();
         }
 

--- a/JMMServer/Commands/CommandProcessorImages.cs
+++ b/JMMServer/Commands/CommandProcessorImages.cs
@@ -23,25 +23,9 @@ namespace JMMServer.Commands
 
         public event QueueCountChangedHandler OnQueueCountChangedEvent;
 
-        protected void OQueueCountChanged(QueueCountEventArgs ev)
-        {
-            if (OnQueueCountChangedEvent != null)
-            {
-                OnQueueCountChangedEvent(ev);
-            }
-        }
-
         public delegate void QueueStateChangedHandler(QueueStateEventArgs ev);
 
         public event QueueStateChangedHandler OnQueueStateChangedEvent;
-
-        protected void OQueueStateChanged(QueueStateEventArgs ev)
-        {
-            if (OnQueueStateChangedEvent != null)
-            {
-                OnQueueStateChangedEvent(ev);
-            }
-        }
 
         private bool paused = false;
 

--- a/JMMServer/Commands/CommandRequest_DownloadImage.cs
+++ b/JMMServer/Commands/CommandRequest_DownloadImage.cs
@@ -27,13 +27,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority2; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_DownloadImage, EntityID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.DownloadImage, extraParams = new string[] { EntityID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/CommandRequest_HashFile.cs
+++ b/JMMServer/Commands/CommandRequest_HashFile.cs
@@ -22,13 +22,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority4; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_HashingFile, FileName);
+                return new QueueStateStruct() { queueState = QueueStateEnum.HashingFile, extraParams = new string[] { FileName }  };
             }
         }
 

--- a/JMMServer/Commands/CommandRequest_MovieDBSearchAnime.cs
+++ b/JMMServer/Commands/CommandRequest_MovieDBSearchAnime.cs
@@ -21,13 +21,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SearchTMDb, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SearchTMDb, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/CommandRequest_ProcessFile.cs
+++ b/JMMServer/Commands/CommandRequest_ProcessFile.cs
@@ -24,16 +24,14 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority3; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
                 if (vlocal != null)
-                    return string.Format(JMMServer.Properties.Resources.Command_FileInfo, vlocal.FullServerPath);
+                    return new QueueStateStruct() { queueState = QueueStateEnum.FileInfo, extraParams = new string[] { vlocal.FullServerPath } };
                 else
-                    return string.Format(JMMServer.Properties.Resources.Command_FileInfo, VideoLocalID);
+                    return new QueueStateStruct() { queueState = QueueStateEnum.FileInfo, extraParams = new string[] { VideoLocalID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/CommandRequest_ReadMediaInfo.cs
+++ b/JMMServer/Commands/CommandRequest_ReadMediaInfo.cs
@@ -21,13 +21,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority4; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_ReadingMedia, VideoLocalID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.ReadingMedia, extraParams = new string[] { VideoLocalID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/CommandRequest_RefreshAnime.cs
+++ b/JMMServer/Commands/CommandRequest_RefreshAnime.cs
@@ -29,13 +29,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority5; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_Refresh, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.Refresh, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/ICommandRequest.cs
+++ b/JMMServer/Commands/ICommandRequest.cs
@@ -7,6 +7,6 @@ namespace JMMServer.Commands
         void ProcessCommand();
         bool LoadFromDBCommand(CommandRequest cq);
         CommandRequestPriority DefaultPriority { get; }
-        string PrettyDescription { get; }
+        QueueStateStruct PrettyDescription { get; }
     }
 }

--- a/JMMServer/Commands/MAL/CommandRequest_MALDownloadStatusFromMAL.cs
+++ b/JMMServer/Commands/MAL/CommandRequest_MALDownloadStatusFromMAL.cs
@@ -17,13 +17,11 @@ namespace JMMServer.Commands.MAL
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_DownloadMalWatched);
+                return new QueueStateStruct() { queueState = QueueStateEnum.DownloadMalWatched, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/MAL/CommandRequest_MALSearchAnime.cs
+++ b/JMMServer/Commands/MAL/CommandRequest_MALSearchAnime.cs
@@ -20,13 +20,11 @@ namespace JMMServer.Commands.MAL
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SearchMal, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SearchMal, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/MAL/CommandRequest_MALUpdatedWatchedStatus.cs
+++ b/JMMServer/Commands/MAL/CommandRequest_MALUpdatedWatchedStatus.cs
@@ -19,13 +19,11 @@ namespace JMMServer.Commands.MAL
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_UpdateMALWatched, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.UpdateMALWatched, extraParams = new string[] { AnimeID.ToString() }  };
             }
         }
 

--- a/JMMServer/Commands/MAL/CommandRequest_MALUploadStatusToMAL.cs
+++ b/JMMServer/Commands/MAL/CommandRequest_MALUploadStatusToMAL.cs
@@ -16,13 +16,11 @@ namespace JMMServer.Commands.MAL
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_UploadMALWatched);
+                return new QueueStateStruct() { queueState = QueueStateEnum.UploadMALWatched, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/QueueStateEventArgs.cs
+++ b/JMMServer/Commands/QueueStateEventArgs.cs
@@ -4,9 +4,9 @@ namespace JMMServer.Commands
 {
     public class QueueStateEventArgs : EventArgs
     {
-        public readonly string QueueState;
+        public readonly QueueStateStruct QueueState;
 
-        public QueueStateEventArgs(string queueState)
+        public QueueStateEventArgs(QueueStateStruct queueState)
         {
             QueueState = queueState;
         }

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktCollectionEpisode.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktCollectionEpisode.cs
@@ -24,13 +24,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SyncTraktEpisodes, AnimeEpisodeID, Action);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SyncTraktEpisodes, extraParams = new string[] { AnimeEpisodeID.ToString(), Action.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktHistoryEpisode.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktHistoryEpisode.cs
@@ -24,13 +24,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_TraktAddHistory, AnimeEpisodeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.TraktAddHistory, extraParams = new string[] { AnimeEpisodeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktSearchAnime.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktSearchAnime.cs
@@ -24,13 +24,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SearchTrakt, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SearchTrakt, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktSyncCollection.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktSyncCollection.cs
@@ -18,13 +18,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SyncTrakt);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SyncTrakt, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktSyncCollectionSeries.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktSyncCollectionSeries.cs
@@ -19,13 +19,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SyncTraktSeries, SeriesName);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SyncTraktSeries, extraParams = new string[] { SeriesName } };
             }
         }
 

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktUpdateAllSeries.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktUpdateAllSeries.cs
@@ -19,13 +19,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_UpdateTrakt);
+                return new QueueStateStruct() { queueState = QueueStateEnum.UpdateTrakt, extraParams = new string[0] };
             }
         }
 

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktUpdateInfoAndImages.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktUpdateInfoAndImages.cs
@@ -17,13 +17,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_UpdateTraktData, TraktID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.UpdateTraktData, extraParams = new string[] { TraktID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/TvDB/CommandRequest_TvDBDownloadImages.cs
+++ b/JMMServer/Commands/TvDB/CommandRequest_TvDBDownloadImages.cs
@@ -17,13 +17,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_DownloadTvDBImages, TvDBSeriesID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.DownloadTvDBImages, extraParams = new string[] { TvDBSeriesID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/TvDB/CommandRequest_TvDBSearchAnime.cs
+++ b/JMMServer/Commands/TvDB/CommandRequest_TvDBSearchAnime.cs
@@ -20,13 +20,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_SearchTvDB, AnimeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.SearchTvDB, extraParams = new string[] { AnimeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/TvDB/CommandRequest_TvDBUpdateSeriesAndEpisodes.cs
+++ b/JMMServer/Commands/TvDB/CommandRequest_TvDBUpdateSeriesAndEpisodes.cs
@@ -17,13 +17,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority8; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(ServerSettings.Culture);
-
-                return string.Format(JMMServer.Properties.Resources.Command_GettingTvDB, TvDBSeriesID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.GettingTvDB, extraParams = new string[] { TvDBSeriesID.ToString() }  };
             }
         }
 

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBMAL.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBMAL.cs
@@ -16,9 +16,11 @@ namespace JMMServer.Commands.WebCache
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
-            get { return string.Format("Deleting cross ref for Anidb to MAL from web cache: {0}", AnimeID); }
+            get {
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheDeleteXRefAniDBMAL, extraParams = new string[] { AnimeID.ToString() } };
+            }
         }
 
         public CommandRequest_WebCacheDeleteXRefAniDBMAL()

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBOther.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBOther.cs
@@ -15,9 +15,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
-            get { return string.Format("Deleting cross ref for Anidb to Other from web cache: {0}", AnimeID); }
+            get {
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheDeleteXRefAniDBOther, extraParams = new string[] { AnimeID.ToString() } };
+            }
         }
 
         public CommandRequest_WebCacheDeleteXRefAniDBOther()

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBTrakt.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBTrakt.cs
@@ -19,9 +19,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
-            get { return string.Format("Deleting cross ref for Anidb to Trakt from web cache: {0}", AnimeID); }
+            get {
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheDeleteXRefAniDBTrakt, extraParams = new string[] { AnimeID.ToString() } };
+            }
         }
 
         public CommandRequest_WebCacheDeleteXRefAniDBTrakt()

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBTvDB.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefAniDBTvDB.cs
@@ -19,9 +19,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
-            get { return string.Format("Deleting cross ref for Anidb to TvDB from web cache: {0}", AnimeID); }
+            get {
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheDeleteXRefAniDBTvDB, extraParams = new string[] { AnimeID.ToString() } };
+            }
         }
 
         public CommandRequest_WebCacheDeleteXRefAniDBTvDB()

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefFileEpisode.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheDeleteXRefFileEpisode.cs
@@ -14,11 +14,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                return string.Format("Deleting cross ref for file to episode to web cache: {0}-{1}", Hash, EpisodeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheDeleteXRefFileEpisode, extraParams = new string[] { Hash, EpisodeID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBMAL.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBMAL.cs
@@ -15,11 +15,11 @@ namespace JMMServer.Commands.WebCache
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                return string.Format("Sending cross ref for Anidb to MAL from web cache: {0}", CrossRef_AniDB_MALID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheSendXRefAniDBMAL, extraParams = new string[] { CrossRef_AniDB_MALID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBOther.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBOther.cs
@@ -15,11 +15,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                return string.Format("Sending cross ref for Anidb to Other from web cache: {0}", CrossRef_AniDB_OtherID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheSendXRefAniDBOther, extraParams = new string[] { CrossRef_AniDB_OtherID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBTrakt.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBTrakt.cs
@@ -15,11 +15,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                return string.Format("Sending cross ref for Anidb to Trakt from web cache: {0}", CrossRef_AniDB_TraktID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheSendXRefAniDBTrakt, extraParams = new string[] { CrossRef_AniDB_TraktID.ToString() } }; 
             }
         }
 

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBTvDB.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefAniDBTvDB.cs
@@ -15,11 +15,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                return string.Format("Sending cross ref for Anidb to TvDB from web cache: {0}", CrossRef_AniDB_TvDBID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheSendXRefAniDBTvDB, extraParams = new string[] { CrossRef_AniDB_TvDBID.ToString() } };
             }
         }
 

--- a/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefFileEpisode.cs
+++ b/JMMServer/Commands/WebCache/CommandRequest_WebCacheSendXRefFileEpisode.cs
@@ -14,11 +14,11 @@ namespace JMMServer.Commands
             get { return CommandRequestPriority.Priority9; }
         }
 
-        public string PrettyDescription
+        public QueueStateStruct PrettyDescription
         {
             get
             {
-                return string.Format("Sending cross ref for file to episode to web cache: {0}", CrossRef_File_EpisodeID);
+                return new QueueStateStruct() { queueState = QueueStateEnum.WebCacheSendXRefFileEpisode, extraParams = new string[] { CrossRef_File_EpisodeID.ToString() } };  
             }
         }
 

--- a/JMMServer/JMMServer.csproj
+++ b/JMMServer/JMMServer.csproj
@@ -349,6 +349,11 @@
     <Compile Include="PlexAndKodi\Helper.cs" />
     <Compile Include="PlexAndKodi\BaseObject.cs" />
     <Compile Include="PlexAndKodi\Utf8SringWriter.cs" />
+    <Compile Include="Properties\Resources.de.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.de.resx</DependentUpon>
+    </Compile>
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/JMMServer/JMMServiceImplementation.cs
+++ b/JMMServer/JMMServiceImplementation.cs
@@ -2539,13 +2539,19 @@ namespace JMMServer
             try
             {
                 contract.HashQueueCount = JMMService.CmdProcessorHasher.QueueCount;
-                contract.HashQueueState = JMMService.CmdProcessorHasher.QueueState;
+                contract.HashQueueState = JMMService.CmdProcessorHasher.QueueState.formatMessage(); //Deprecated since 3.6.0.0
+                contract.HashQueueStateId = (int)JMMService.CmdProcessorHasher.QueueState.queueState;
+                contract.HashQueueStateParams = JMMService.CmdProcessorHasher.QueueState.extraParams;
 
                 contract.GeneralQueueCount = JMMService.CmdProcessorGeneral.QueueCount;
-                contract.GeneralQueueState = JMMService.CmdProcessorGeneral.QueueState;
+                contract.GeneralQueueState = JMMService.CmdProcessorGeneral.QueueState.formatMessage(); //Deprecated since 3.6.0.0
+                contract.GeneralQueueStateId = (int)JMMService.CmdProcessorGeneral.QueueState.queueState;
+                contract.GeneralQueueStateParams = JMMService.CmdProcessorGeneral.QueueState.extraParams;
 
-                contract.ImagesQueueCount = JMMService.CmdProcessorImages.QueueCount;
-                contract.ImagesQueueState = JMMService.CmdProcessorImages.QueueState;
+                contract.ImagesQueueCount = JMMService.CmdProcessorImages.QueueCount; 
+                contract.ImagesQueueState = JMMService.CmdProcessorImages.QueueState.formatMessage(); //Deprecated since 3.6.0.0
+                contract.ImagesQueueStateId = (int)JMMService.CmdProcessorImages.QueueState.queueState;
+                contract.ImagesQueueStateParams = JMMService.CmdProcessorImages.QueueState.extraParams;
 
                 contract.IsBanned = JMMService.AnidbProcessor.IsBanned;
                 contract.BanReason = JMMService.AnidbProcessor.BanTime.ToString();

--- a/JMMServer/JMMServiceImplementationMetro.cs
+++ b/JMMServer/JMMServiceImplementationMetro.cs
@@ -28,13 +28,19 @@ namespace JMMServer
             try
             {
                 contract.HashQueueCount = JMMService.CmdProcessorHasher.QueueCount;
-                contract.HashQueueState = JMMService.CmdProcessorHasher.QueueState;
+                contract.HashQueueState = JMMService.CmdProcessorHasher.QueueState.formatMessage(); //Deprecated since 3.6.0.0
+                contract.HashQueueStateId = (int)JMMService.CmdProcessorHasher.QueueState.queueState;
+                contract.HashQueueStateParams = JMMService.CmdProcessorHasher.QueueState.extraParams;
 
                 contract.GeneralQueueCount = JMMService.CmdProcessorGeneral.QueueCount;
-                contract.GeneralQueueState = JMMService.CmdProcessorGeneral.QueueState;
+                contract.GeneralQueueState = JMMService.CmdProcessorGeneral.QueueState.formatMessage(); //Deprecated since 3.6.0.0
+                contract.GeneralQueueStateId = (int)JMMService.CmdProcessorGeneral.QueueState.queueState;
+                contract.GeneralQueueStateParams = JMMService.CmdProcessorGeneral.QueueState.extraParams;
 
                 contract.ImagesQueueCount = JMMService.CmdProcessorImages.QueueCount;
-                contract.ImagesQueueState = JMMService.CmdProcessorImages.QueueState;
+                contract.ImagesQueueState = JMMService.CmdProcessorImages.QueueState.formatMessage(); //Deprecated since 3.6.0.0
+                contract.ImagesQueueStateId = (int)JMMService.CmdProcessorImages.QueueState.queueState;
+                contract.ImagesQueueStateParams = JMMService.CmdProcessorImages.QueueState.extraParams;
 
                 contract.IsBanned = JMMService.AnidbProcessor.IsBanned;
                 contract.BanReason = JMMService.AnidbProcessor.BanTime.ToString();

--- a/JMMServer/Properties/Resources.Designer.cs
+++ b/JMMServer/Properties/Resources.Designer.cs
@@ -782,6 +782,96 @@ namespace JMMServer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deleting cross ref for Anidb to MAL from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheDeleteXRefAniDBMAL {
+            get {
+                return ResourceManager.GetString("Command_WebCacheDeleteXRefAniDBMAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting cross ref for Anidb to Other from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheDeleteXRefAniDBOther {
+            get {
+                return ResourceManager.GetString("Command_WebCacheDeleteXRefAniDBOther", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting cross ref for Anidb to Trakt from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheDeleteXRefAniDBTrakt {
+            get {
+                return ResourceManager.GetString("Command_WebCacheDeleteXRefAniDBTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting cross ref for Anidb to TvDB from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheDeleteXRefAniDBTvDB {
+            get {
+                return ResourceManager.GetString("Command_WebCacheDeleteXRefAniDBTvDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting cross ref for file to episode to web cache: {0}-{1}.
+        /// </summary>
+        internal static string Command_WebCacheDeleteXRefFileEpisode {
+            get {
+                return ResourceManager.GetString("Command_WebCacheDeleteXRefFileEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sending cross ref for Anidb to MAL from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheSendXRefAniDBMAL {
+            get {
+                return ResourceManager.GetString("Command_WebCacheSendXRefAniDBMAL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sending cross ref for Anidb to Other from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheSendXRefAniDBOther {
+            get {
+                return ResourceManager.GetString("Command_WebCacheSendXRefAniDBOther", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sending cross ref for Anidb to Trakt from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheSendXRefAniDBTrakt {
+            get {
+                return ResourceManager.GetString("Command_WebCacheSendXRefAniDBTrakt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sending cross ref for Anidb to TvDB from web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheSendXRefAniDBTvDB {
+            get {
+                return ResourceManager.GetString("Command_WebCacheSendXRefAniDBTvDB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sending cross ref for file to episode to web cache: {0}.
+        /// </summary>
+        internal static string Command_WebCacheSendXRefFileEpisode {
+            get {
+                return ResourceManager.GetString("Command_WebCacheSendXRefFileEpisode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Confirm.
         /// </summary>
         internal static string Confirm {

--- a/JMMServer/Properties/Resources.Designer.cs
+++ b/JMMServer/Properties/Resources.Designer.cs
@@ -1106,15 +1106,6 @@ namespace JMMServer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Getting release group info from UDP API: {0}.
-        /// </summary>
-        internal static string Getting_release_group_info_from_UDP_API___0_ {
-            get {
-                return ResourceManager.GetString("Getting release group info from UDP API: {0}", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Clear all queued hash commands.
         /// </summary>
         internal static string Hash_Clear {

--- a/JMMServer/Properties/Resources.de.resx
+++ b/JMMServer/Properties/Resources.de.resx
@@ -808,9 +808,6 @@ Du kannst nur einen Ordner aufgeführt als Drop-Ziel haben.</value>
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Suche nach Anime auf The TvDB: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Erste Gruppe Freigabeinfo von UDP-API: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Update AniDB Informationen </value>
   </data>
@@ -855,5 +852,35 @@ Du kannst nur einen Ordner aufgeführt als Drop-Ziel haben.</value>
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Changelog</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Cross Ref für Anidb, MAL aus Webcache löschen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Cross Ref für Anidb zueinander aus Webcache löschen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Cross Ref für Anidb, Trakt aus Webcache löschen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Cross Ref für Anidb, TvDB aus Webcache löschen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Cross Ref für Episode an Web-Cache-Datei löschen: {0}-{1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Cross Ref für Anidb zu MAL senden aus Web-Cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Cross Ref für Anidb zu anderen senden aus Web-Cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Schickend cross Ref für Anidb Trakt aus dem Webcache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Cross Ref für Anidb zu TvDB senden aus Web-Cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Cross Ref für Episode an Web-Cache-Datei senden: {0}!</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.en-GB.resx
+++ b/JMMServer/Properties/Resources.en-GB.resx
@@ -808,9 +808,6 @@ You can only have one folder listed as a Drop Destination.</value>
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Searching for anime on The TvDB: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Getting release group info from UDP API: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Update AniDB Info</value>
   </data>
@@ -855,5 +852,35 @@ You can only have one folder listed as a Drop Destination.</value>
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Changelog</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to MAL from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to Other from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to Trakt from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to TvDB from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Deleting cross ref for file to episode to web cache: {0}-{1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Sending cross ref for Anidb to MAL from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Sending cross ref for Anidb to Other from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Sending cross ref for Anidb to Trakt from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Sending cross ref for Anidb to TvDB from web cache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Sending cross ref for file to episode to web cache: {0}!</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.es.resx
+++ b/JMMServer/Properties/Resources.es.resx
@@ -808,9 +808,6 @@ Sólo puede tener una carpeta que aparece como un destino de la gota.</value>
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Busca anime en The TvDB: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Obtener información del grupo de lanzamiento del API de UDP: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Actualizar información de AniDB</value>
   </data>
@@ -855,5 +852,35 @@ Sólo puede tener una carpeta que aparece como un destino de la gota.</value>
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Registro de cambios</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Eliminar referencia para Anidb de la Cruz a MAL de la memoria caché de web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Eliminar referencia para Anidb de la Cruz otro de caché web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Eliminar referencia para Anidb de la Cruz a Trakt de caché web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Eliminar referencia para Anidb de la Cruz a TvDB de caché web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Eliminar referencia a episodio para caché web archivo de la Cruz: {0}-{1}.</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Enviar referencia de la Cruz para Anidb a MAL de caché web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Enviar referencia de la Cruz para Anidb otro de caché web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Enviar referencia de la Cruz para Anidb Trakt de caché web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Enviar referencia de la Cruz para Anidb TvDB de caché web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Enviar referencia de la Cruz a episodio para caché web archivo: {0}!</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.fr.resx
+++ b/JMMServer/Properties/Resources.fr.resx
@@ -808,9 +808,6 @@ Vous ne pouvez avoir qu'un seul dossier répertorié comme une Destination de Dr
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Vous cherchez une anime sur le TvDB : {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Obtenir info presse groupe de UDP API: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Mise à jour d'informations AniDB</value>
   </data>
@@ -855,5 +852,35 @@ Vous ne pouvez avoir qu'un seul dossier répertorié comme une Destination de Dr
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Changelog</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Suppression de croix ref pour Anidb pour MAL de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Suppression de croix ref pour Anidb aux autres de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Suppression de croix ref pour Anidb à Trakt de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Suppression de croix ref pour Anidb à TvDB de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Suppression ref croix pour le fichier d&amp;#39;épisode à cache Web: {0} - {1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Envoi croisé Réf pour Anidb à MAL de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Envoi de croix ref pour Anidb aux autres de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Envoi de croix ref pour Anidb à Trakt de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Envoi croisé Réf pour Anidb à TvDB de cache web: {0} !</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Envoi de croix Réf fichier épisode de cache web: {0} !</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.it.resx
+++ b/JMMServer/Properties/Resources.it.resx
@@ -808,9 +808,6 @@ Si può avere solo una cartella elencata come una destinazione di Drop.</value>
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Alla ricerca di anime su The TvDB: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Ottenere informazioni di gruppo di rilascio dall'API di UDP: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Aggiornamento AniDB Info</value>
   </data>
@@ -855,5 +852,35 @@ Si può avere solo una cartella elencata come una destinazione di Drop.</value>
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Changelog</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>L'eliminazione di croce ref per Anidb a MAL dalla cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>L'eliminazione Croce ref per Anidb altro dalla cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>L'eliminazione di croce ref per Anidb a Trakt dalla cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Eliminazione ref croce per Anidb a TvDB dalla cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>L'eliminazione di croce ref per file all'episodio di cache web: {0}-{1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Invio croce rif per Anidb a MAL da cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Invio croce rif per Anidb altro dalla cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Invio croce rif per Anidb a Trakt da cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Invio croce rif per Anidb a TvDB da cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Invio croce rif per file all'episodio di cache web: {0}!</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.nl.resx
+++ b/JMMServer/Properties/Resources.nl.resx
@@ -808,9 +808,6 @@ U kunt slechts één map vermeld als een Drop bestemming hebben.</value>
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Op zoek naar anime op de TvDB: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Krijgen van groep versieinfo van UDP-API: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Update ANiDB informatie</value>
   </data>
@@ -855,5 +852,35 @@ U kunt slechts één map vermeld als een Drop bestemming hebben.</value>
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Changelog</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Cross-ref voor Anidb aan de MAL uit webcache verwijderen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Cross-ref voor Anidb naar andere uit webcache verwijderen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Cross-ref voor Anidb aan Trakt uit webcache verwijderen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Cross-ref voor Anidb aan TvDB uit webcache verwijderen: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Cross-ref aflevering webcache-bestand verwijderen: {0}-{1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Cross-ref voor Anidb vanaf naar stuurt MAL webcache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Cross-ref voor Anidb vanaf naar stuurt andere webcache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Cross-ref voor Anidb vanaf naar stuurt Trakt webcache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Cross-ref voor Anidb vanaf naar stuurt TvDB webcache: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Cross-ref voor aflevering webcache bestand verzenden: {0}!</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.pl.resx
+++ b/JMMServer/Properties/Resources.pl.resx
@@ -808,9 +808,6 @@ Możesz skonfigurować tylko jeden folder docelowym.</value>
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Wyszukiwanie anime na The TvDB: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Pobieranie informacji o grupie z UDP API: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Ustawienia konta AniDB</value>
   </data>
@@ -855,5 +852,35 @@ Możesz skonfigurować tylko jeden folder docelowym.</value>
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Lista zmian</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Usunięcie Krzyża ref do Anidb do MAL z pamięci podręcznej sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Usunięcie Krzyża ref do Anidb do innych z pamięci podręcznej sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Usuwanie Krzyża ref do Anidb do Trakt z pamięci podręcznej sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Usunięcie Krzyża ref do Anidb do TvDB z pamięci podręcznej sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Usunięcie Krzyża ref do odcinek do pamięci podręcznej sieci web pliku: {0}-{1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Wysyłanie krzyż ref Anidb do MAL z pamięci podręcznej w sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Wysyłanie krzyż ref Anidb do innych z pamięci podręcznej w sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Wysłanie krzyż ref do Anidb na Trakt z pamięci podręcznej w sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Wysyłanie krzyż ref do Anidb do TvDB z pamięci podręcznej w sieci web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Wysyłanie krzyż ref do odcinek do pamięci podręcznej sieci web pliku: {0}!</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.pt.resx
+++ b/JMMServer/Properties/Resources.pt.resx
@@ -694,9 +694,6 @@ Você só pode ter uma pasta listada como um destino de soltar.</value>
   <data name="Command_GetReleaseInfo" xml:space="preserve">
     <value>Recebendo informações sobre o grupo lançamento de UDP API: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Recebendo informações sobre o grupo lançamento de UDP API: {0}</value>
-  </data>
   <data name="Command_SearchTMDb" xml:space="preserve">
     <value>À procura de anime na The MovieDB: {0}</value>
   </data>
@@ -855,5 +852,35 @@ Você só pode ter uma pasta listada como um destino de soltar.</value>
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Changelog</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Excluindo Cruz ref para Anidb de MAL do cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Excluindo Cruz ref para Anidb outros de cache de web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Excluindo Cruz ref para Anidb para Trakt do cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Excluindo Cruz ref para Anidb para TvDB de cache de web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Exclusão de cruz ref para arquivo episódio ao cache de web: {0}-{1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Envio Cruz ref para Anidb para MAL do cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Enviar Cruz ref para Anidb outros do cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Devolver o Cruz ref para Anidb Trakt cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Envio Cruz ref para Anidb para TvDB do cache web: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Envio de cruz ref para arquivo episódio ao cache de web: {0}!</value>
   </data>
 </root>

--- a/JMMServer/Properties/Resources.resx
+++ b/JMMServer/Properties/Resources.resx
@@ -905,4 +905,34 @@ You can only have one folder listed as a Drop Destination.</value>
   <data name="Update_Changelog" xml:space="preserve">
     <value>Changelog</value>
   </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to MAL from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to Other from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to Trakt from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Deleting cross ref for Anidb to TvDB from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Deleting cross ref for file to episode to web cache: {0}-{1}</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Sending cross ref for Anidb to MAL from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Sending cross ref for Anidb to Other from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Sending cross ref for Anidb to Trakt from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Sending cross ref for Anidb to TvDB from web cache: {0}</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Sending cross ref for file to episode to web cache: {0}</value>
+  </data>
 </root>

--- a/JMMServer/Properties/Resources.resx
+++ b/JMMServer/Properties/Resources.resx
@@ -740,9 +740,6 @@ You can only have one folder listed as a Drop Destination.</value>
   <data name="Command_GetReleaseInfo" xml:space="preserve">
     <value>Getting release group info from UDP API: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Getting release group info from UDP API: {0}</value>
-  </data>
   <data name="Command_SearchTMDb" xml:space="preserve">
     <value>Searching for anime on The MovieDB: {0}</value>
   </data>

--- a/JMMServer/Properties/Resources.ru.resx
+++ b/JMMServer/Properties/Resources.ru.resx
@@ -808,9 +808,6 @@
   <data name="Command_SearchTvDB" xml:space="preserve">
     <value>Поиск для аниме на TvDB: {0}</value>
   </data>
-  <data name="Getting release group info from UDP API: {0}" xml:space="preserve">
-    <value>Получать информацию о группе выпуска от UDP API: {0}</value>
-  </data>
   <data name="Settings_AniDB" xml:space="preserve">
     <value>Обновление информации о AniDB</value>
   </data>
@@ -855,5 +852,35 @@
   </data>
   <data name="Update_Changelog" xml:space="preserve">
     <value>История изменений</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBMAL" xml:space="preserve">
+    <value>Удаление крест ref Anidb к MAL веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBOther" xml:space="preserve">
+    <value>Удаление крест ref Anidb к другой веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTrakt" xml:space="preserve">
+    <value>Удаление крест ref Anidb тракт из веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefAniDBTvDB" xml:space="preserve">
+    <value>Удаление крест ref Anidb к TvDB веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheDeleteXRefFileEpisode" xml:space="preserve">
+    <value>Удаление крест ref для эпизод в веб кэш файла: {0}-{1}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBMAL" xml:space="preserve">
+    <value>Отправки перекрестные ссылки для Anidb мал из веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBOther" xml:space="preserve">
+    <value>Отправка перекрестные ссылки для Anidb другу из веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTrakt" xml:space="preserve">
+    <value>Отправки перекрестные ссылки для Anidb тракт из веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefAniDBTvDB" xml:space="preserve">
+    <value>Отправки перекрестные ссылки для Anidb TvDB из веб-кэша: {0}!</value>
+  </data>
+  <data name="Command_WebCacheSendXRefFileEpisode" xml:space="preserve">
+    <value>Отправка перекрестные ссылки для эпизод в веб кэш файла: {0}!</value>
   </data>
 </root>

--- a/JMMServer/UI/ServerInfo.cs
+++ b/JMMServer/UI/ServerInfo.cs
@@ -69,7 +69,7 @@ namespace JMMServer
 
         void CmdProcessorImages_OnQueueStateChangedEvent(Commands.QueueStateEventArgs ev)
         {
-            ImagesQueueState = ev.QueueState;
+            ImagesQueueState = ev.QueueState.formatMessage();
         }
 
         void CmdProcessorImages_OnQueueCountChangedEvent(Commands.QueueCountEventArgs ev)
@@ -79,7 +79,7 @@ namespace JMMServer
 
         void CmdProcessorHasher_OnQueueStateChangedEvent(Commands.QueueStateEventArgs ev)
         {
-            HasherQueueState = ev.QueueState;
+            HasherQueueState = ev.QueueState.formatMessage();
         }
 
         void CmdProcessorHasher_OnQueueCountChangedEvent(Commands.QueueCountEventArgs ev)
@@ -89,7 +89,7 @@ namespace JMMServer
 
         void CmdProcessorGeneral_OnQueueStateChangedEvent(Commands.QueueStateEventArgs ev)
         {
-            GeneralQueueState = ev.QueueState;
+            GeneralQueueState = ev.QueueState.formatMessage();
         }
 
         void CmdProcessorGeneral_OnQueueCountChangedEvent(Commands.QueueCountEventArgs ev)


### PR DESCRIPTION
Refactor queue status to use struct instead of strings, which stops server language from leaking into the client. Closes JMM client issue 382.