### PR TITLE
Prevent duplicate filter being created

### DIFF
--- a/JMMServer/Repositories/GroupFilterRepository.cs
+++ b/JMMServer/Repositories/GroupFilterRepository.cs
@@ -110,8 +110,7 @@ namespace JMMServer.Repositories
                 GroupFilter cwatching =
                     lockedGFs.FirstOrDefault(
                         a =>
-                            a.GroupFilterName.Equals(Constants.GroupFilterName.ContinueWatching,
-                                StringComparison.InvariantCultureIgnoreCase));
+                            a.FilterType == (int)GroupFilterType.ContinueWatching);
                 if (cwatching != null && cwatching.FilterType != (int) GroupFilterType.ContinueWatching)
                 {
                     ServerState.Instance.CurrentSetupStatus = string.Format(DatabaseHelper.InitCacheTitle, t, " Creating Continue Watching filter");


### PR DESCRIPTION
Fixes continue watching from being recreated. @maxpiva could you take a look at this fix? I know we talked that it is not ok to use filter type but in this case I think it is ok because we don't care if it is a system or user created filter, as long as we have any filter of type continue watching we shouldn't auto-create more.