### PR TITLE
Performance improvements for AniDB_Anime cache initialisation

### DIFF
--- a/JMMServer/AniDBHelper.cs
+++ b/JMMServer/AniDBHelper.cs
@@ -12,6 +12,7 @@ using JMMServer.Commands;
 using JMMServer.Commands.Azure;
 using JMMServer.Entities;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 
@@ -1096,20 +1097,21 @@ namespace JMMServer
 
             AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
             AniDB_Anime anime = null;
+            ISessionWrapper sessionWrapper = session.Wrap();
 
             bool skip = true;
             if (forceRefresh)
                 skip = false;
             else
             {
-                anime = repAnime.GetByAnimeID(session, animeID);
+                anime = repAnime.GetByAnimeID(sessionWrapper, animeID);
                 if (anime == null) skip = false;
             }
 
             if (skip)
             {
                 if (anime == null)
-                    anime = repAnime.GetByAnimeID(session, animeID);
+                    anime = repAnime.GetByAnimeID(sessionWrapper, animeID);
 
                 return anime;
             }
@@ -1144,10 +1146,11 @@ namespace JMMServer
         {
             AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
             AniDB_Anime anime = null;
+            ISessionWrapper sessionWrapper = session.Wrap();
 
             logger.Trace("cmdResult.Anime: {0}", getAnimeCmd.Anime);
 
-            anime = repAnime.GetByAnimeID(session, animeID);
+            anime = repAnime.GetByAnimeID(sessionWrapper, animeID);
             if (anime == null)
                 anime = new AniDB_Anime();
             anime.PopulateAndSaveFromHTTP(session, getAnimeCmd.Anime, getAnimeCmd.Episodes, getAnimeCmd.Titles,
@@ -1163,7 +1166,7 @@ namespace JMMServer
             // create AnimeEpisode records for all episodes in this anime
             // only if we have a series
             AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
-            AnimeSeries ser = repSeries.GetByAnimeID(session, animeID);
+            AnimeSeries ser = repSeries.GetByAnimeID(sessionWrapper, animeID);
             repAnime.Save(anime);
             if (ser != null)
             {
@@ -1181,9 +1184,9 @@ namespace JMMServer
             //StatsCache.Instance.UpdateAnimeContract(session, anime.AnimeID);
 
             // download character images
-            foreach (AniDB_Anime_Character animeChar in anime.GetAnimeCharacters(session))
+            foreach (AniDB_Anime_Character animeChar in anime.GetAnimeCharacters(session.Wrap()))
             {
-                AniDB_Character chr = animeChar.GetCharacter(session);
+                AniDB_Character chr = animeChar.GetCharacter(sessionWrapper);
                 if (chr == null) continue;
 
                 if (ServerSettings.AniDB_DownloadCharacters)

--- a/JMMServer/Collections/EmptyLookup.cs
+++ b/JMMServer/Collections/EmptyLookup.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace JMMServer.Collections
+{
+    public class EmptyLookup<TKey, TElement> : ILookup<TKey, TElement>
+    {
+        public static readonly EmptyLookup<TKey, TElement> Instance = new EmptyLookup<TKey, TElement>();
+
+        public bool Contains(TKey key) => false;
+
+        public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator() => Enumerable.Empty<IGrouping<TKey, TElement>>().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => Enumerable.Empty<IGrouping<TKey, TElement>>().GetEnumerator();
+
+        public IEnumerable<TElement> this[TKey key] => Enumerable.Empty<TElement>();
+
+        public int Count => 0;
+    }
+}

--- a/JMMServer/Collections/EnumerableExtensions.cs
+++ b/JMMServer/Collections/EnumerableExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace JMMServer.Collections
+{
+    public static class EnumerableExtensions
+    {
+        public static ILookup<TKey, TSource> ToLazyLookup<TKey, TSource>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> comparer = null)
+        {
+            return LazyLookup<TKey, TSource>.Create(source, keySelector, comparer);
+        }
+
+        public static ILookup<TKey, TElement> ToLazyLookup<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
+            Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer = null)
+        {
+            return LazyLookup<TKey, TElement>.Create(source, keySelector, elementSelector, comparer);
+        }
+
+        public static IEnumerable<TSource[]> Batch<TSource>(this IEnumerable<TSource> source, int size)
+        {
+            TSource[] bucket = null;
+            var count = 0;
+
+            foreach (var item in source)
+            {
+                if (bucket == null)
+                {
+                    bucket = new TSource[size];
+                }
+
+                bucket[count++] = item;
+
+                if (count != size)
+                {
+                    continue;
+                }
+
+                yield return bucket;
+
+                bucket = null;
+                count = 0;
+            }
+
+            // Return the last bucket with remaining elements
+            if (bucket != null && count > 0)
+            {
+                Array.Resize(ref bucket, count);
+
+                yield return bucket;
+            }
+        }
+    }
+}

--- a/JMMServer/Collections/LazyLookup.cs
+++ b/JMMServer/Collections/LazyLookup.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JMMServer.Collections
+{
+    public class LazyLookup<TKey, TElement> : ILookup<TKey, TElement>
+    {
+        private readonly Lazy<ILookup<TKey, TElement>> _lookup;
+
+        public LazyLookup(Lazy<ILookup<TKey, TElement>> lookup)
+        {
+            if (lookup == null)
+                throw new ArgumentNullException(nameof(lookup));
+
+            _lookup = lookup;
+        }
+
+        public static LazyLookup<TKey, TElement> Create(IEnumerable<TElement> source, Func<TElement, TKey> keySelector,
+            IEqualityComparer<TKey> comparer = null)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (keySelector == null)
+                throw new ArgumentNullException(nameof(keySelector));
+
+            var lazyLookup = new Lazy<ILookup<TKey, TElement>>(() => source.ToLookup(keySelector, comparer), false);
+
+            return new LazyLookup<TKey, TElement>(lazyLookup);
+        }
+
+        public static LazyLookup<TKey, TElement> Create<TSource>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
+            Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer = null)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (keySelector == null)
+                throw new ArgumentNullException(nameof(keySelector));
+            if (elementSelector == null)
+                throw new ArgumentNullException(nameof(elementSelector));
+
+            var lazyLookup = new Lazy<ILookup<TKey, TElement>>(() => source.ToLookup(keySelector, elementSelector, comparer), false);
+
+            return new LazyLookup<TKey, TElement>(lazyLookup);
+        }
+
+        public bool Contains(TKey key) => _lookup.Value.Contains(key);
+
+        public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator() => _lookup.Value.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => _lookup.Value.GetEnumerator();
+
+        public IEnumerable<TElement> this[TKey key] => _lookup.Value[key];
+
+        public int Count => _lookup.Value.Count;
+    }
+}

--- a/JMMServer/Commands/AniDB/CommandRequest_GetFile.cs
+++ b/JMMServer/Commands/AniDB/CommandRequest_GetFile.cs
@@ -7,6 +7,7 @@ using AniDBAPI;
 using JMMServer.Commands.AniDB;
 using JMMServer.Entities;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 
 namespace JMMServer.Commands
 {
@@ -123,7 +124,7 @@ namespace JMMServer.Commands
                     {
                         using (var session = JMMService.SessionFactory.OpenSession())
                         {
-                            anime.UpdateContractDetailed(session);
+                            anime.UpdateContractDetailed(session.Wrap());
                         }
                     }
                     AnimeSeries series = repo.GetByAnimeID(aniFile.AnimeID);

--- a/JMMServer/Commands/CommandRequest_MovieDBSearchAnime.cs
+++ b/JMMServer/Commands/CommandRequest_MovieDBSearchAnime.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using JMMServer.Entities;
 using JMMServer.Providers.MovieDB;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 
 namespace JMMServer.Commands
@@ -51,6 +52,8 @@ namespace JMMServer.Commands
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
+
                     // first check if the user wants to use the web cache
                     if (ServerSettings.WebCache_TvDB_Get)
                     {
@@ -64,7 +67,7 @@ namespace JMMServer.Commands
                             if (crossRef != null)
                             {
                                 int movieID = int.Parse(crossRef.CrossRefID);
-                                MovieDB_Movie movie = repMovies.GetByOnlineID(session, movieID);
+                                MovieDB_Movie movie = repMovies.GetByOnlineID(sessionWrapper, movieID);
                                 if (movie == null)
                                 {
                                     // update the info from online
@@ -87,7 +90,7 @@ namespace JMMServer.Commands
 
                     string searchCriteria = "";
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
-                    AniDB_Anime anime = repAnime.GetByAnimeID(session, AnimeID);
+                    AniDB_Anime anime = repAnime.GetByAnimeID(sessionWrapper, AnimeID);
                     if (anime == null) return;
 
                     searchCriteria = anime.MainTitle;
@@ -100,7 +103,7 @@ namespace JMMServer.Commands
 
                     if (results.Count == 0)
                     {
-                        foreach (AniDB_Anime_Title title in anime.GetTitles(session))
+                        foreach (AniDB_Anime_Title title in anime.GetTitles(sessionWrapper))
                         {
                             if (title.TitleType.ToUpper() != Constants.AnimeTitleType.Official.ToUpper()) continue;
 

--- a/JMMServer/Commands/Trakt/CommandRequest_TraktSearchAnime.cs
+++ b/JMMServer/Commands/Trakt/CommandRequest_TraktSearchAnime.cs
@@ -9,6 +9,7 @@ using JMMServer.Entities;
 using JMMServer.Providers.TraktTV;
 using JMMServer.Providers.TraktTV.Contracts;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 
 namespace JMMServer.Commands
@@ -55,6 +56,8 @@ namespace JMMServer.Commands
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
+
                     // first check if the user wants to use the web cache
                     if (ServerSettings.WebCache_Trakt_Get)
                     {
@@ -92,7 +95,7 @@ namespace JMMServer.Commands
                     // lets try to see locally if we have a tvDB link for this anime
                     // Trakt allows the use of TvDB ID's or their own Trakt ID's
                     CrossRef_AniDB_TvDBV2Repository repCrossRefTvDB = new CrossRef_AniDB_TvDBV2Repository();
-                    List<CrossRef_AniDB_TvDBV2> xrefTvDBs = repCrossRefTvDB.GetByAnimeID(session, AnimeID);
+                    List<CrossRef_AniDB_TvDBV2> xrefTvDBs = repCrossRefTvDB.GetByAnimeID(sessionWrapper, AnimeID);
                     if (xrefTvDBs != null && xrefTvDBs.Count > 0)
                     {
                         foreach (CrossRef_AniDB_TvDBV2 tvXRef in xrefTvDBs)
@@ -149,7 +152,7 @@ namespace JMMServer.Commands
                     // finally lets try searching Trakt directly
                     string searchCriteria = "";
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
-                    AniDB_Anime anime = repAnime.GetByAnimeID(session, AnimeID);
+                    AniDB_Anime anime = repAnime.GetByAnimeID(sessionWrapper, AnimeID);
                     if (anime == null) return;
 
                     searchCriteria = anime.MainTitle;
@@ -162,7 +165,7 @@ namespace JMMServer.Commands
 
                     if (results.Count == 0)
                     {
-                        foreach (AniDB_Anime_Title title in anime.GetTitles(session))
+                        foreach (AniDB_Anime_Title title in anime.GetTitles(sessionWrapper))
                         {
                             if (title.TitleType.ToUpper() != Constants.AnimeTitleType.Official.ToUpper()) continue;
 

--- a/JMMServer/Databases/DatabaseFixes.cs
+++ b/JMMServer/Databases/DatabaseFixes.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using AniDBAPI;
 using JMMServer.Entities;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NLog;
 
 namespace JMMServer.Databases
@@ -212,6 +213,7 @@ namespace JMMServer.Databases
 
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     List<CrossRef_AniDB_TvDB> xrefsTvDB = repCrossRefTvDB.GetAll();
                     foreach (CrossRef_AniDB_TvDB xrefTvDB in xrefsTvDB)
                     {
@@ -221,7 +223,7 @@ namespace JMMServer.Databases
                         xrefNew.TvDBID = xrefTvDB.TvDBID;
                         xrefNew.TvDBSeasonNumber = xrefTvDB.TvDBSeasonNumber;
 
-                        TvDB_Series ser = xrefTvDB.GetTvDBSeries(session);
+                        TvDB_Series ser = xrefTvDB.GetTvDBSeries(sessionWrapper);
                         if (ser != null)
                             xrefNew.TvDBTitle = ser.SeriesName;
 
@@ -265,7 +267,7 @@ namespace JMMServer.Databases
                         xrefNew.AniDBStartEpisodeType = (int) enEpisodeType.Special;
                         xrefNew.AniDBStartEpisodeNumber = 1;
 
-                        TvDB_Series ser = xrefTvDB.GetTvDBSeries(session);
+                        TvDB_Series ser = xrefTvDB.GetTvDBSeries(sessionWrapper);
                         if (ser != null)
                             xrefNew.TvDBTitle = ser.SeriesName;
 

--- a/JMMServer/Entities/AniDB_Anime.cs
+++ b/JMMServer/Entities/AniDB_Anime.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -7,12 +8,14 @@ using System.Xml.Serialization;
 using AniDBAPI;
 
 using JMMContracts;
+using JMMServer.Collections;
 using JMMServer.Commands;
 using JMMServer.ImageDownload;
 using JMMServer.LZ4;
 using JMMServer.Properties;
 using JMMServer.Providers.Azure;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 using NLog;
@@ -209,11 +212,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBEpisodes(session);
+                return GetTvDBEpisodes(session.Wrap());
             }
         }
 
-        public List<TvDB_Episode> GetTvDBEpisodes(ISession session)
+        public List<TvDB_Episode> GetTvDBEpisodes(ISessionWrapper session)
         {
             List<TvDB_Episode> tvDBEpisodes = new List<TvDB_Episode>();
 
@@ -234,11 +237,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDictTvDBEpisodes(session);
+                return GetDictTvDBEpisodes(session.Wrap());
             }
         }
 
-        public Dictionary<int, TvDB_Episode> GetDictTvDBEpisodes(ISession session)
+        public Dictionary<int, TvDB_Episode> GetDictTvDBEpisodes(ISessionWrapper session)
         {
             if (dictTvDBEpisodes == null)
             {
@@ -275,11 +278,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDictTvDBSeasons(session);
+                return GetDictTvDBSeasons(session.Wrap());
             }
         }
 
-        public Dictionary<int, int> GetDictTvDBSeasons(ISession session)
+        public Dictionary<int, int> GetDictTvDBSeasons(ISessionWrapper session)
         {
             if (dictTvDBSeasons == null)
             {
@@ -318,11 +321,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDictTvDBSeasonsSpecials(session);
+                return GetDictTvDBSeasonsSpecials(session.Wrap());
             }
         }
 
-        public Dictionary<int, int> GetDictTvDBSeasonsSpecials(ISession session)
+        public Dictionary<int, int> GetDictTvDBSeasonsSpecials(ISessionWrapper session)
         {
             if (dictTvDBSeasonsSpecials == null)
             {
@@ -379,11 +382,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetCrossRefTvDBV2(session);
+                return GetCrossRefTvDBV2(session.Wrap());
             }
         }
 
-        public List<CrossRef_AniDB_TvDBV2> GetCrossRefTvDBV2(ISession session)
+        public List<CrossRef_AniDB_TvDBV2> GetCrossRefTvDBV2(ISessionWrapper session)
         {
             CrossRef_AniDB_TvDBV2Repository repCrossRef = new CrossRef_AniDB_TvDBV2Repository();
             return repCrossRef.GetByAnimeID(session, this.AnimeID);
@@ -421,11 +424,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBSeries(session);
+                return GetTvDBSeries(session.Wrap());
             }
         }
 
-        public List<TvDB_Series> GetTvDBSeries(ISession session)
+        public List<TvDB_Series> GetTvDBSeries(ISessionWrapper session)
         {
             TvDB_SeriesRepository repSeries = new TvDB_SeriesRepository();
 
@@ -446,11 +449,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBImageFanarts(session);
+                return GetTvDBImageFanarts(session.Wrap());
             }
         }
 
-        public List<TvDB_ImageFanart> GetTvDBImageFanarts(ISession session)
+        public List<TvDB_ImageFanart> GetTvDBImageFanarts(ISessionWrapper session)
         {
             List<TvDB_ImageFanart> ret = new List<TvDB_ImageFanart>();
 
@@ -471,11 +474,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBImagePosters(session);
+                return GetTvDBImagePosters(session.Wrap());
             }
         }
 
-        public List<TvDB_ImagePoster> GetTvDBImagePosters(ISession session)
+        public List<TvDB_ImagePoster> GetTvDBImagePosters(ISessionWrapper session)
         {
             List<TvDB_ImagePoster> ret = new List<TvDB_ImagePoster>();
 
@@ -496,11 +499,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBImageWideBanners(session);
+                return GetTvDBImageWideBanners(session.Wrap());
             }
         }
 
-        public List<TvDB_ImageWideBanner> GetTvDBImageWideBanners(ISession session)
+        public List<TvDB_ImageWideBanner> GetTvDBImageWideBanners(ISessionWrapper session)
         {
             List<TvDB_ImageWideBanner> ret = new List<TvDB_ImageWideBanner>();
 
@@ -519,14 +522,14 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetCrossRefMovieDB(session);
+                return GetCrossRefMovieDB(session.Wrap());
             }
         }
 
-        public CrossRef_AniDB_Other GetCrossRefMovieDB(ISession session)
+        public CrossRef_AniDB_Other GetCrossRefMovieDB(ISessionWrapper criteriaFactory)
         {
             CrossRef_AniDB_OtherRepository repCrossRef = new CrossRef_AniDB_OtherRepository();
-            return repCrossRef.GetByAnimeIDAndType(session, this.AnimeID, CrossRefType.MovieDB);
+            return repCrossRef.GetByAnimeIDAndType(criteriaFactory, this.AnimeID, CrossRefType.MovieDB);
         }
 
 
@@ -534,28 +537,28 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetMovieDBMovie(session);
+                return GetMovieDBMovie(session.Wrap());
             }
         }
 
-        public MovieDB_Movie GetMovieDBMovie(ISession session)
+        public MovieDB_Movie GetMovieDBMovie(ISessionWrapper criteriaFactory)
         {
-            CrossRef_AniDB_Other xref = GetCrossRefMovieDB(session);
+            CrossRef_AniDB_Other xref = GetCrossRefMovieDB(criteriaFactory);
             if (xref == null) return null;
 
             MovieDB_MovieRepository repMovies = new MovieDB_MovieRepository();
-            return repMovies.GetByOnlineID(session, Int32.Parse(xref.CrossRefID));
+            return repMovies.GetByOnlineID(criteriaFactory, Int32.Parse(xref.CrossRefID));
         }
 
         public List<MovieDB_Fanart> GetMovieDBFanarts()
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetMovieDBFanarts(session);
+                return GetMovieDBFanarts(session.Wrap());
             }
         }
 
-        public List<MovieDB_Fanart> GetMovieDBFanarts(ISession session)
+        public List<MovieDB_Fanart> GetMovieDBFanarts(ISessionWrapper session)
         {
             CrossRef_AniDB_Other xref = GetCrossRefMovieDB(session);
             if (xref == null) return new List<MovieDB_Fanart>();
@@ -568,11 +571,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetMovieDBPosters(session);
+                return GetMovieDBPosters(session.Wrap());
             }
         }
 
-        public List<MovieDB_Poster> GetMovieDBPosters(ISession session)
+        public List<MovieDB_Poster> GetMovieDBPosters(ISessionWrapper session)
         {
             CrossRef_AniDB_Other xref = GetCrossRefMovieDB(session);
             if (xref == null) return new List<MovieDB_Poster>();
@@ -585,14 +588,14 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDefaultPoster(session);
+                return GetDefaultPoster(session.Wrap());
             }
         }
 
-        public AniDB_Anime_DefaultImage GetDefaultPoster(ISession session)
+        public AniDB_Anime_DefaultImage GetDefaultPoster(ISessionWrapper criteriaFactory)
         {
             AniDB_Anime_DefaultImageRepository repDefaults = new AniDB_Anime_DefaultImageRepository();
-            return repDefaults.GetByAnimeIDAndImagezSizeType(session, this.AnimeID, (int) ImageSizeType.Poster);
+            return repDefaults.GetByAnimeIDAndImagezSizeType(criteriaFactory, this.AnimeID, (int) ImageSizeType.Poster);
         }
 
         public string PosterPathNoDefault
@@ -604,15 +607,17 @@ namespace JMMServer.Entities
             }
         }
 
+        
+
         public string GetDefaultPosterPathNoBlanks()
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDefaultPosterPathNoBlanks(session);
+                return GetDefaultPosterPathNoBlanks(session.Wrap());
             }
         }
 
-        public string GetDefaultPosterPathNoBlanks(ISession session)
+        public string GetDefaultPosterPathNoBlanks(ISessionWrapper session)
         {
             AniDB_Anime_DefaultImage defaultPoster = GetDefaultPoster(session);
             if (defaultPoster == null)
@@ -662,11 +667,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDefaultPosterDetailsNoBlanks(session);
+                return GetDefaultPosterDetailsNoBlanks(session.Wrap());
             }
         }
 
-        public ImageDetails GetDefaultPosterDetailsNoBlanks(ISession session)
+        public ImageDetails GetDefaultPosterDetailsNoBlanks(ISessionWrapper session)
         {
             ImageDetails details = new ImageDetails() {ImageType = JMMImageType.AniDB_Cover, ImageID = this.AnimeID};
             AniDB_Anime_DefaultImage defaultPoster = GetDefaultPoster(session);
@@ -730,25 +735,25 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDefaultFanart(session);
+                return GetDefaultFanart(session.Wrap());
             }
         }
 
-        public AniDB_Anime_DefaultImage GetDefaultFanart(ISession session)
+        public AniDB_Anime_DefaultImage GetDefaultFanart(ISessionWrapper factory)
         {
             AniDB_Anime_DefaultImageRepository repDefaults = new AniDB_Anime_DefaultImageRepository();
-            return repDefaults.GetByAnimeIDAndImagezSizeType(session, this.AnimeID, (int) ImageSizeType.Fanart);
+            return repDefaults.GetByAnimeIDAndImagezSizeType(factory, this.AnimeID, (int) ImageSizeType.Fanart);
         }
 
         public ImageDetails GetDefaultFanartDetailsNoBlanks()
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDefaultFanartDetailsNoBlanks(session);
+                return GetDefaultFanartDetailsNoBlanks(session.Wrap());
             }
         }
 
-        public ImageDetails GetDefaultFanartDetailsNoBlanks(ISession session)
+        public ImageDetails GetDefaultFanartDetailsNoBlanks(ISessionWrapper session)
         {
             Random fanartRandom = new Random();
 
@@ -840,11 +845,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDefaultFanartOnlineURL(session);
+                return GetDefaultFanartOnlineURL(session.Wrap());
             }
         }
 
-        public string GetDefaultFanartOnlineURL(ISession session)
+        public string GetDefaultFanartOnlineURL(ISessionWrapper session)
         {
             Random fanartRandom = new Random();
 
@@ -911,70 +916,70 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetDefaultWideBanner(session);
+                return GetDefaultWideBanner(session.Wrap());
             }
         }
 
-        public AniDB_Anime_DefaultImage GetDefaultWideBanner(ISession session)
+        public AniDB_Anime_DefaultImage GetDefaultWideBanner(ISessionWrapper session)
         {
             AniDB_Anime_DefaultImageRepository repDefaults = new AniDB_Anime_DefaultImageRepository();
             return repDefaults.GetByAnimeIDAndImagezSizeType(session, this.AnimeID, (int) ImageSizeType.WideBanner);
         }
 
-	    public ImageDetails GetDefaultWideBannerDetailsNoBlanks(ISession session)
-	    {
-		    Random bannerRandom = new Random();
+        public ImageDetails GetDefaultWideBannerDetailsNoBlanks(ISessionWrapper session)
+        {
+            Random bannerRandom = new Random();
 
-		    ImageDetails details = null;
-		    if (GetDefaultWideBanner() == null)
-		    {
-			    // get a random banner (only tvdb)
-			    if (this.AnimeTypeEnum == enAnimeType.Movie)
-			    {
-				    // MovieDB doesn't have banners
-				    return null;
-			    }
-			    else
-			    {
-				    List<TvDB_ImageWideBanner> banners = GetTvDBImageWideBanners(session);
-				    if (banners.Count == 0) return null;
+            ImageDetails details = null;
+            if (GetDefaultWideBanner() == null)
+            {
+                // get a random banner (only tvdb)
+                if (this.AnimeTypeEnum == enAnimeType.Movie)
+                {
+                    // MovieDB doesn't have banners
+                    return null;
+                }
+                else
+                {
+                    List<TvDB_ImageWideBanner> banners = GetTvDBImageWideBanners(session);
+                    if (banners.Count == 0) return null;
 
-				    TvDB_ImageWideBanner tvBanner = banners[bannerRandom.Next(0, banners.Count)];
-				    details = new ImageDetails()
-				    {
-					    ImageType = JMMImageType.TvDB_Banner,
-					    ImageID = tvBanner.TvDB_ImageWideBannerID
-				    };
-				    return details;
-			    }
-		    }
-		    else
-		    {
-			    ImageEntityType imageType = (ImageEntityType) GetDefaultWideBanner().ImageParentType;
+                    TvDB_ImageWideBanner tvBanner = banners[bannerRandom.Next(0, banners.Count)];
+                    details = new ImageDetails()
+                    {
+                        ImageType = JMMImageType.TvDB_Banner,
+                        ImageID = tvBanner.TvDB_ImageWideBannerID
+                    };
+                    return details;
+                }
+            }
+            else
+            {
+                ImageEntityType imageType = (ImageEntityType) GetDefaultWideBanner().ImageParentType;
 
-			    switch (imageType)
-			    {
-				    case ImageEntityType.TvDB_Banner:
+                switch (imageType)
+                {
+                    case ImageEntityType.TvDB_Banner:
 
-					    TvDB_ImageWideBannerRepository repTvBanner = new TvDB_ImageWideBannerRepository();
-					    TvDB_ImageWideBanner tvBanner = repTvBanner.GetByID(session,
-						    GetDefaultWideBanner(session).ImageParentID);
-					    if (tvBanner != null)
-						    details = new ImageDetails()
-						    {
-							    ImageType = JMMImageType.TvDB_Banner,
-							    ImageID = tvBanner.TvDB_ImageWideBannerID
-						    };
+                        TvDB_ImageWideBannerRepository repTvBanner = new TvDB_ImageWideBannerRepository();
+                        TvDB_ImageWideBanner tvBanner = repTvBanner.GetByID(session,
+                            GetDefaultWideBanner(session).ImageParentID);
+                        if (tvBanner != null)
+                            details = new ImageDetails()
+                            {
+                                ImageType = JMMImageType.TvDB_Banner,
+                                ImageID = tvBanner.TvDB_ImageWideBannerID
+                            };
 
-					    return details;
+                        return details;
 
-			    }
-		    }
+                }
+            }
 
-		    return null;
-	    }
+            return null;
+        }
 
-	    public string AnimeTypeRAW
+        public string AnimeTypeRAW
         {
             get
             {
@@ -1058,11 +1063,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTags(session);
+                return GetTags(session.Wrap());
             }
         }
 
-        public List<AniDB_Tag> GetTags(ISession session)
+        public List<AniDB_Tag> GetTags(ISessionWrapper session)
         {
             AniDB_TagRepository repTag = new AniDB_TagRepository();
 
@@ -1096,19 +1101,19 @@ namespace JMMServer.Entities
 		}
         */
 
-        public List<CustomTag> GetCustomTagsForAnime(ISession session)
+        public List<CustomTag> GetCustomTagsForAnime(ISessionWrapper session)
         {
             CustomTagRepository repTags = new CustomTagRepository();
             return repTags.GetByAnimeID(session, AnimeID);
         }
 
-        public List<AniDB_Tag> GetAniDBTags(ISession session)
+        public List<AniDB_Tag> GetAniDBTags(ISessionWrapper session)
         {
             AniDB_TagRepository repTags = new AniDB_TagRepository();
             return repTags.GetByAnimeID(session, AnimeID);
         }
 
-        public List<AniDB_Anime_Tag> GetAnimeTags(ISession session)
+        public List<AniDB_Anime_Tag> GetAnimeTags(ISessionWrapper session)
         {
             AniDB_Anime_TagRepository repAnimeTags = new AniDB_Anime_TagRepository();
             return repAnimeTags.GetByAnimeID(session, AnimeID);
@@ -1118,11 +1123,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetRelatedAnime(session);
+                return GetRelatedAnime(session.Wrap());
             }
         }
 
-        public List<AniDB_Anime_Relation> GetRelatedAnime(ISession session)
+        public List<AniDB_Anime_Relation> GetRelatedAnime(ISessionWrapper session)
         {
             AniDB_Anime_RelationRepository repRels = new AniDB_Anime_RelationRepository();
             return repRels.GetByAnimeID(session, AnimeID);
@@ -1156,11 +1161,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAllRelatedAnime(session);
+                return GetAllRelatedAnime(session.Wrap());
             }
         }
 
-        public List<AniDB_Anime> GetAllRelatedAnime(ISession session)
+        public List<AniDB_Anime> GetAllRelatedAnime(ISessionWrapper session)
         {
             List<AniDB_Anime> relList = new List<AniDB_Anime>();
             List<int> relListIDs = new List<int>();
@@ -1174,11 +1179,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAnimeCharacters(session);
+                return GetAnimeCharacters(session.Wrap());
             }
         }
 
-        public List<AniDB_Anime_Character> GetAnimeCharacters(ISession session)
+        public List<AniDB_Anime_Character> GetAnimeCharacters(ISessionWrapper session)
         {
             AniDB_Anime_CharacterRepository repRels = new AniDB_Anime_CharacterRepository();
             return repRels.GetByAnimeID(session, AnimeID);
@@ -1245,11 +1250,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTitles(session);
+                return GetTitles(session.Wrap());
             }
         }
 
-        public List<AniDB_Anime_Title> GetTitles(ISession session)
+        public List<AniDB_Anime_Title> GetTitles(ISessionWrapper session)
         {
             AniDB_Anime_TitleRepository repTitles = new AniDB_Anime_TitleRepository();
             return repTitles.GetByAnimeID(session, AnimeID);
@@ -1306,11 +1311,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetFormattedTitle(session);
+                return GetFormattedTitle(session.Wrap());
             }
         }
 
-        public string GetFormattedTitle(ISession session)
+        public string GetFormattedTitle(ISessionWrapper session)
         {
             List<AniDB_Anime_Title> thisTitles = this.GetTitles(session);
             return GetFormattedTitle(thisTitles);
@@ -1415,7 +1420,7 @@ namespace JMMServer.Entities
             }
         }
 
-        public List<AniDB_Episode> GetAniDBEpisodes(ISession session)
+        public List<AniDB_Episode> GetAniDBEpisodes(ISessionWrapper session)
         {
             AniDB_EpisodeRepository repEps = new AniDB_EpisodeRepository();
             return repEps.GetByAnimeID(session, AnimeID);
@@ -1479,54 +1484,55 @@ namespace JMMServer.Entities
             logger.Trace(String.Format("PopulateAndSaveFromHTTP: for {0} - {1}", animeInfo.AnimeID, animeInfo.MainTitle));
             logger.Trace("------------------------------------------------");
 
-            DateTime start0 = DateTime.Now;
-
+            Stopwatch taskTimer = new Stopwatch();
+            Stopwatch totalTimer = Stopwatch.StartNew();
+            
             Populate(animeInfo);
 
             // save now for FK purposes
             AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
             repAnime.Save(session, this);
 
-            DateTime start = DateTime.Now;
+            taskTimer.Start();
 
             CreateEpisodes(session, eps);
-            TimeSpan ts = DateTime.Now - start;
-            logger.Trace(String.Format("CreateEpisodes in : {0}", ts.TotalMilliseconds));
-            start = DateTime.Now;
+            taskTimer.Stop();
+            logger.Trace("CreateEpisodes in : " + taskTimer.ElapsedMilliseconds);
+            taskTimer.Restart();
 
             CreateTitles(session, titles);
-            ts = DateTime.Now - start;
-            logger.Trace(String.Format("CreateTitles in : {0}", ts.TotalMilliseconds));
-            start = DateTime.Now;
+            taskTimer.Stop();
+            logger.Trace("CreateTitles in : " + taskTimer.ElapsedMilliseconds);
+            taskTimer.Restart();
 
             CreateTags(session, tags);
-            ts = DateTime.Now - start;
-            logger.Trace(String.Format("CreateTags in : {0}", ts.TotalMilliseconds));
-            start = DateTime.Now;
+            taskTimer.Stop();
+            logger.Trace("CreateTags in : " + taskTimer.ElapsedMilliseconds);
+            taskTimer.Restart();
 
             CreateCharacters(session, chars);
-            ts = DateTime.Now - start;
-            logger.Trace(String.Format("CreateCharacters in : {0}", ts.TotalMilliseconds));
-            start = DateTime.Now;
+            taskTimer.Stop();
+            logger.Trace("CreateCharacters in : " + taskTimer.ElapsedMilliseconds);
+            taskTimer.Restart();
 
             CreateRelations(session, rels, downloadRelations);
-            ts = DateTime.Now - start;
-            logger.Trace(String.Format("CreateRelations in : {0}", ts.TotalMilliseconds));
-            start = DateTime.Now;
+            taskTimer.Stop();
+            logger.Trace("CreateRelations in : " + taskTimer.ElapsedMilliseconds);
+            taskTimer.Restart();
 
             CreateSimilarAnime(session, sims);
-            ts = DateTime.Now - start;
-            logger.Trace(String.Format("CreateSimilarAnime in : {0}", ts.TotalMilliseconds));
-            start = DateTime.Now;
+            taskTimer.Stop();
+            logger.Trace("CreateSimilarAnime in : " + taskTimer.ElapsedMilliseconds);
+            taskTimer.Restart();
 
             CreateRecommendations(session, recs);
-            ts = DateTime.Now - start;
-            logger.Trace(String.Format("CreateRecommendations in : {0}", ts.TotalMilliseconds));
-            start = DateTime.Now;
+            taskTimer.Stop();
+            logger.Trace("CreateRecommendations in : " + taskTimer.ElapsedMilliseconds);
+            taskTimer.Restart();
 
             repAnime.Save(this);
-            ts = DateTime.Now - start0;
-            logger.Trace(String.Format("TOTAL TIME in : {0}", ts.TotalMilliseconds));
+            totalTimer.Stop();
+            logger.Trace("TOTAL TIME in : " + totalTimer.ElapsedMilliseconds);
             logger.Trace("------------------------------------------------");
         }
 
@@ -1696,10 +1702,11 @@ namespace JMMServer.Entities
             // find all the current links, and then later remove the ones that are no longer relevant
             List<AniDB_Anime_Tag> currentTags = repTagsXRefs.GetByAnimeID(AnimeID);
             List<int> newTagIDs = new List<int>();
+            ISessionWrapper sessionWrapper = session.Wrap();
 
             foreach (Raw_AniDB_Tag rawtag in tags)
             {
-                AniDB_Tag tag = repTags.GetByTagID(rawtag.TagID, session);
+                AniDB_Tag tag = repTags.GetByTagID(rawtag.TagID, sessionWrapper);
                 if (tag == null) tag = new AniDB_Tag();
 
                 tag.Populate(rawtag);
@@ -1707,7 +1714,7 @@ namespace JMMServer.Entities
 
                 newTagIDs.Add(tag.TagID);
 
-                AniDB_Anime_Tag anime_tag = repTagsXRefs.GetByAnimeIDAndTagID(session, rawtag.AnimeID, rawtag.TagID);
+                AniDB_Anime_Tag anime_tag = repTagsXRefs.GetByAnimeIDAndTagID(sessionWrapper, rawtag.AnimeID, rawtag.TagID);
                 if (anime_tag == null) anime_tag = new AniDB_Anime_Tag();
 
                 anime_tag.Populate(rawtag);
@@ -1748,9 +1755,10 @@ namespace JMMServer.Entities
             AniDB_Anime_CharacterRepository repAnimeChars = new AniDB_Anime_CharacterRepository();
             AniDB_Character_SeiyuuRepository repCharSeiyuu = new AniDB_Character_SeiyuuRepository();
             AniDB_SeiyuuRepository repSeiyuu = new AniDB_SeiyuuRepository();
+            ISessionWrapper sessionWrapper = session.Wrap();
 
             // delete all the existing cross references just in case one has been removed
-            List<AniDB_Anime_Character> animeChars = repAnimeChars.GetByAnimeID(session, AnimeID);
+            List<AniDB_Anime_Character> animeChars = repAnimeChars.GetByAnimeID(sessionWrapper, AnimeID);
 
             using (var transaction = session.BeginTransaction())
             {
@@ -1786,7 +1794,7 @@ namespace JMMServer.Entities
 
             foreach (Raw_AniDB_Character rawchar in chars)
             {
-                AniDB_Character chr = repChars.GetByCharID(session, rawchar.CharID);
+                AniDB_Character chr = repChars.GetByCharID(sessionWrapper, rawchar.CharID);
                 if (chr == null)
                     chr = new AniDB_Character();
 
@@ -1991,7 +1999,23 @@ namespace JMMServer.Entities
             return sb.ToString();
         }
 
-        private Contract_AniDBAnime GenerateContract(ISession session, List<AniDB_Anime_Title> titles)
+        private Contract_AniDBAnime GenerateContract(ISessionWrapper session, List<AniDB_Anime_Title> titles)
+        {
+            List<Contract_AniDB_Character> characters = GetCharactersContract();
+            Contract_AniDBAnime contract = GenerateContract(titles, null, characters);
+            AniDB_Anime_DefaultImage defFanart = GetDefaultFanart(session);
+            AniDB_Anime_DefaultImage defPoster = GetDefaultPoster(session);
+            AniDB_Anime_DefaultImage defBanner = GetDefaultWideBanner(session);
+
+            contract.DefaultImageFanart = defFanart?.ToContract(session);
+            contract.DefaultImagePoster = defPoster?.ToContract(session);
+            contract.DefaultImageWideBanner = defBanner?.ToContract(session);
+
+            return contract;
+        }
+
+        private Contract_AniDBAnime GenerateContract(List<AniDB_Anime_Title> titles, DefaultAnimeImages defaultImages,
+            List<Contract_AniDB_Character> characters)
         {
             Contract_AniDBAnime contract = new Contract_AniDBAnime();
             contract.AirDate = this.AirDate;
@@ -2002,12 +2026,12 @@ namespace JMMServer.Entities
                 new HashSet<string>(
                     this.AllTags.Split(new char[] {'|'}, StringSplitOptions.RemoveEmptyEntries)
                         .Select(a => a.Trim())
-                        .Where(a => !string.IsNullOrEmpty(a)).Distinct(StringComparer.InvariantCultureIgnoreCase), StringComparer.InvariantCultureIgnoreCase);
+                        .Where(a => !string.IsNullOrEmpty(a)), StringComparer.InvariantCultureIgnoreCase);
             contract.AllTitles =
                 new HashSet<string>(
                     this.AllTitles.Split(new char[] {'|'}, StringSplitOptions.RemoveEmptyEntries)
                         .Select(a => a.Trim())
-                        .Where(a => !string.IsNullOrEmpty(a)).Distinct(StringComparer.InvariantCultureIgnoreCase), StringComparer.InvariantCultureIgnoreCase);
+                        .Where(a => !string.IsNullOrEmpty(a)), StringComparer.InvariantCultureIgnoreCase);
             contract.AnimeID = this.AnimeID;
             contract.AnimeNfo = this.AnimeNfo;
             contract.AnimePlanetID = this.AnimePlanetID;
@@ -2037,13 +2061,15 @@ namespace JMMServer.Entities
             contract.VoteCount = this.VoteCount;
             contract.FormattedTitle = GetFormattedTitle(titles);
             contract.DisableExternalLinksFlag = this.DisableExternalLinksFlag;
-            AniDB_Anime_DefaultImage defFanart = this.GetDefaultFanart(session);
-            if (defFanart != null) contract.DefaultImageFanart = defFanart.ToContract(session);
-            AniDB_Anime_DefaultImage defPoster = this.GetDefaultPoster(session);
-            if (defPoster != null) contract.DefaultImagePoster = defPoster.ToContract(session);
-            AniDB_Anime_DefaultImage defBanner = this.GetDefaultWideBanner(session);
-            if (defBanner != null) contract.DefaultImageWideBanner = defBanner.ToContract(session);
-            contract.Characters = GetCharactersContract();
+            contract.Characters = characters;
+
+            if (defaultImages != null)
+            {
+                contract.DefaultImageFanart = defaultImages.Fanart?.ToContract();
+                contract.DefaultImagePoster = defaultImages.Poster?.ToContract();
+                contract.DefaultImageWideBanner = defaultImages.WideBanner?.ToContract();
+            }
+
             return contract;
         }
 
@@ -2063,7 +2089,7 @@ namespace JMMServer.Entities
                 {
                     AniDB_Character chr = repChar.GetByCharID(animeChar.CharID);
                     if (chr != null)
-                        chars.Add(chr.ToContract(animeChar));
+                        chars.Add(chr.ToContract(animeChar.CharType));
                 }
             }
             catch (Exception ex)
@@ -2073,7 +2099,133 @@ namespace JMMServer.Entities
             return chars;
         }
 
-        public void UpdateContractDetailed(ISession session)
+        public static void UpdateContractDetailedBatch(ISessionWrapper session, IReadOnlyCollection<AniDB_Anime> animeColl)
+        {
+            if (session == null)
+                throw new ArgumentNullException(nameof(session));
+            if (animeColl == null)
+                throw new ArgumentNullException(nameof(animeColl));
+
+            var repTitles = new AniDB_Anime_TitleRepository();
+            var repAnimeTags = new AniDB_Anime_TagRepository();
+            var repTags = new AniDB_TagRepository();
+            var repCustomTags = new CustomTagRepository();
+            var repAdHoc = new AdhocRepository();
+            var repVotes = new AniDB_VoteRepository();
+            var repAnime = new AniDB_AnimeRepository();
+            var repChars = new AniDB_CharacterRepository();
+            int[] animeIds = animeColl.Select(a => a.AnimeID).ToArray();
+
+            var titlesByAnime = repTitles.GetByAnimeIDs(session, animeIds);
+            var animeTagsByAnime = repAnimeTags.GetByAnimeIDs(session, animeIds);
+            var tagsByAnime = repTags.GetByAnimeIDs(session, animeIds);
+            var custTagsByAnime = repCustomTags.GetByAnimeIDs(session, animeIds);
+            var voteByAnime = repVotes.GetByAnimeIDs(session, animeIds);
+            var audioLangByAnime = repAdHoc.GetAudioLanguageStatsByAnime(session, animeIds);
+            var subtitleLangByAnime = repAdHoc.GetSubtitleLanguageStatsByAnime(session, animeIds);
+            var vidQualByAnime = repAdHoc.GetAllVideoQualityByAnime(session, animeIds);
+            var epVidQualByAnime = repAdHoc.GetEpisodeVideoQualityStatsByAnime(session, animeIds);
+            var defImagesByAnime = repAnime.GetDefaultImagesByAnime(session, animeIds);
+            var charsByAnime = repChars.GetCharacterAndSeiyuuByAnime(session, animeIds);
+
+            foreach (AniDB_Anime anime in animeColl)
+            {
+                var contract = new Contract_AniDB_AnimeDetailed();
+                var animeTitles = titlesByAnime[anime.AnimeID];
+                DefaultAnimeImages defImages;
+
+                defImagesByAnime.TryGetValue(anime.AnimeID, out defImages);
+
+                var characterContracts = (charsByAnime[anime.AnimeID] ?? Enumerable.Empty<AnimeCharacterAndSeiyuu>())
+                    .Select(ac => ac.ToContract())
+                    .ToList();
+
+                contract.AniDBAnime = anime.GenerateContract(animeTitles.ToList(), defImages, characterContracts);
+
+                // Anime titles
+                contract.AnimeTitles = titlesByAnime[anime.AnimeID]
+                    .Select(t => new Contract_AnimeTitle
+                        {
+                            AnimeID = t.AnimeID,
+                            Language = t.Language,
+                            Title = t.Title,
+                            TitleType = t.TitleType
+                        }).ToList();
+
+                // Anime tags
+                var dictAnimeTags = animeTagsByAnime[anime.AnimeID]
+                    .ToDictionary(t => t.TagID);
+
+                contract.Tags = tagsByAnime[anime.AnimeID].Select(t =>
+                    {
+                        AniDB_Anime_Tag animeTag = null;
+                        Contract_AnimeTag ctag = new Contract_AnimeTag
+                            {
+                                GlobalSpoiler = t.GlobalSpoiler,
+                                LocalSpoiler = t.LocalSpoiler,
+                                TagDescription = t.TagDescription,
+                                TagID = t.TagID,
+                                TagName = t.TagName,
+                                Weight = dictAnimeTags.TryGetValue(t.TagID, out animeTag) ? animeTag.Weight : 0
+                            };
+
+                        return ctag;
+                    }).ToList();
+
+                // Custom tags
+                contract.CustomTags = custTagsByAnime[anime.AnimeID]
+                    .Select(t => t.ToContract())
+                    .ToList();
+
+                // Vote
+                AniDB_Vote vote;
+
+                if (voteByAnime.TryGetValue(anime.AnimeID, out vote))
+                {
+                    contract.UserVote = vote.ToContract();
+                }
+
+                LanguageStat langStat;
+
+                // Subtitle languages
+                contract.Stat_AudioLanguages = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+                if (audioLangByAnime.TryGetValue(anime.AnimeID, out langStat))
+                {
+                    contract.Stat_AudioLanguages.UnionWith(langStat.LanguageNames);
+                }
+
+                // Audio languages
+                contract.Stat_SubtitleLanguages = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+                if (subtitleLangByAnime.TryGetValue(anime.AnimeID, out langStat))
+                {
+                    contract.Stat_SubtitleLanguages.UnionWith(langStat.LanguageNames);
+                }
+
+                // Anime video quality
+                HashSet<string> vidQual;
+
+                contract.Stat_AllVideoQuality = vidQualByAnime.TryGetValue(anime.AnimeID, out vidQual) ? vidQual
+                    : new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+                // Episode video quality
+                AnimeVideoQualityStat vidQualStat;
+
+                contract.Stat_AllVideoQuality_Episodes = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+
+                if (epVidQualByAnime.TryGetValue(anime.AnimeID, out vidQualStat) && vidQualStat.VideoQualityEpisodeCount.Count > 0)
+                {
+                    contract.Stat_AllVideoQuality_Episodes.UnionWith(vidQualStat.VideoQualityEpisodeCount
+                        .Where(kvp => kvp.Value >= anime.EpisodeCountNormal)
+                        .Select(kvp => kvp.Key));
+                }
+
+                anime.Contract = contract;
+            }
+        }
+
+        public void UpdateContractDetailed(ISessionWrapper session)
         {
             AniDB_Anime_TitleRepository repTitles = new AniDB_Anime_TitleRepository();
             List<AniDB_Anime_Title> animeTitles = repTitles.GetByAnimeID(session, AnimeID);
@@ -2198,11 +2350,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return ToContractAzure(session);
+                return ToContractAzure(session.Wrap());
             }
         }
 
-        public AnimeFull ToContractAzure(ISession session)
+        public AnimeFull ToContractAzure(ISessionWrapper session)
         {
             AnimeFull contract = new AnimeFull();
             contract.Detail = new AnimeDetail();
@@ -2311,8 +2463,9 @@ namespace JMMServer.Entities
             AnimeSeries ser = new AnimeSeries();
             ser.Populate(this);
 
+            ISessionWrapper sessionWrapper = session.Wrap();
             JMMUserRepository repUsers = new JMMUserRepository();
-            List<JMMUser> allUsers = repUsers.GetAll(session);
+            List<JMMUser> allUsers = repUsers.GetAll(sessionWrapper);
 
             // create the AnimeGroup record
             // check if there are any existing groups we could add this series to
@@ -2320,7 +2473,7 @@ namespace JMMServer.Entities
 
             if (ServerSettings.AutoGroupSeries)
             {
-                List<AnimeGroup> grps = AnimeGroup.GetRelatedGroupsFromAnimeID(session, ser.AniDB_ID, true);
+                List<AnimeGroup> grps = AnimeGroup.GetRelatedGroupsFromAnimeID(sessionWrapper, ser.AniDB_ID, true);
 
                 // only use if there is just one result
 
@@ -2459,7 +2612,7 @@ namespace JMMServer.Entities
             return ser;
         }
 
-        public static void GetRelatedAnimeRecursive(ISession session, int animeID, ref List<AniDB_Anime> relList,
+        public static void GetRelatedAnimeRecursive(ISessionWrapper session, int animeID, ref List<AniDB_Anime> relList,
             ref List<int> relListIDs, ref List<int> searchedIDs)
         {
             AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();

--- a/JMMServer/Entities/AniDB_Anime_Character.cs
+++ b/JMMServer/Entities/AniDB_Anime_Character.cs
@@ -1,6 +1,7 @@
 ﻿using AniDBAPI;
 using JMMContracts;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 
 namespace JMMServer.Entities
@@ -25,11 +26,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetCharacter(session);
+                return GetCharacter(session.Wrap());
             }
         }
 
-        public AniDB_Character GetCharacter(ISession session)
+        public AniDB_Character GetCharacter(ISessionWrapper session)
         {
             AniDB_CharacterRepository repChar = new AniDB_CharacterRepository();
             return repChar.GetByCharID(session, CharID);

--- a/JMMServer/Entities/AniDB_Anime_DefaultImage.cs
+++ b/JMMServer/Entities/AniDB_Anime_DefaultImage.cs
@@ -1,5 +1,6 @@
 ﻿using JMMContracts;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 
 namespace JMMServer.Entities
@@ -16,90 +17,95 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return ToContract(session);
+                return ToContract(session.Wrap());
             }
         }
 
-        public Contract_AniDB_Anime_DefaultImage ToContract(ISession session)
+        public Contract_AniDB_Anime_DefaultImage ToContract(IImageEntity parentImage)
         {
-            Contract_AniDB_Anime_DefaultImage contract = new Contract_AniDB_Anime_DefaultImage();
+            var contract = new Contract_AniDB_Anime_DefaultImage
+                {
+                    AniDB_Anime_DefaultImageID = AniDB_Anime_DefaultImageID,
+                    AnimeID = AnimeID,
+                    ImageParentID = ImageParentID,
+                    ImageParentType = ImageParentType,
+                    ImageType = ImageType
+                };
 
-            contract.AniDB_Anime_DefaultImageID = this.AniDB_Anime_DefaultImageID;
-            contract.AnimeID = this.AnimeID;
-            contract.ImageParentID = this.ImageParentID;
-            contract.ImageParentType = this.ImageParentType;
-            contract.ImageType = this.ImageType;
-
-            contract.MovieFanart = null;
-            contract.MoviePoster = null;
-            contract.TVPoster = null;
-            contract.TVFanart = null;
-            contract.TVWideBanner = null;
-            contract.TraktFanart = null;
-            contract.TraktPoster = null;
-
-            JMMImageType imgType = (JMMImageType) ImageParentType;
+            JMMImageType imgType = (JMMImageType)ImageParentType;
 
             switch (imgType)
             {
                 case JMMImageType.TvDB_Banner:
-
-                    TvDB_ImageWideBannerRepository repBanners = new TvDB_ImageWideBannerRepository();
-                    TvDB_ImageWideBanner banner = repBanners.GetByID(session, ImageParentID);
-                    if (banner != null) contract.TVWideBanner = banner.ToContract();
-
+                    contract.TVWideBanner = (parentImage as TvDB_ImageWideBanner)?.ToContract();
                     break;
-
                 case JMMImageType.TvDB_Cover:
-
-                    TvDB_ImagePosterRepository repPosters = new TvDB_ImagePosterRepository();
-                    TvDB_ImagePoster poster = repPosters.GetByID(session, ImageParentID);
-                    if (poster != null) contract.TVPoster = poster.ToContract();
-
+                    contract.TVPoster = (parentImage as TvDB_ImagePoster)?.ToContract();
                     break;
-
                 case JMMImageType.TvDB_FanArt:
-
-                    TvDB_ImageFanartRepository repFanart = new TvDB_ImageFanartRepository();
-                    TvDB_ImageFanart fanart = repFanart.GetByID(session, ImageParentID);
-                    if (fanart != null) contract.TVFanart = fanart.ToContract();
-
+                    contract.TVFanart = (parentImage as TvDB_ImageFanart)?.ToContract();
                     break;
-
                 case JMMImageType.MovieDB_Poster:
-
-                    MovieDB_PosterRepository repMoviePosters = new MovieDB_PosterRepository();
-                    MovieDB_Poster moviePoster = repMoviePosters.GetByID(session, ImageParentID);
-                    if (moviePoster != null) contract.MoviePoster = moviePoster.ToContract();
-
+                    contract.MoviePoster = (parentImage as MovieDB_Poster)?.ToContract();
                     break;
-
                 case JMMImageType.MovieDB_FanArt:
-
-                    MovieDB_FanartRepository repMovieFanart = new MovieDB_FanartRepository();
-                    MovieDB_Fanart movieFanart = repMovieFanart.GetByID(session, ImageParentID);
-                    if (movieFanart != null) contract.MovieFanart = movieFanart.ToContract();
-
+                    contract.MovieFanart = (parentImage as MovieDB_Fanart)?.ToContract();
                     break;
-
                 case JMMImageType.Trakt_Fanart:
-
-                    Trakt_ImageFanartRepository repTraktFanart = new Trakt_ImageFanartRepository();
-                    Trakt_ImageFanart traktFanart = repTraktFanart.GetByID(session, ImageParentID);
-                    if (traktFanart != null) contract.TraktFanart = traktFanart.ToContract();
-
+                    contract.TraktFanart = (parentImage as Trakt_ImageFanart)?.ToContract();
                     break;
-
                 case JMMImageType.Trakt_Poster:
-
-                    Trakt_ImagePosterRepository repTraktPoster = new Trakt_ImagePosterRepository();
-                    Trakt_ImagePoster traktPoster = repTraktPoster.GetByID(session, ImageParentID);
-                    if (traktPoster != null) contract.TraktPoster = traktPoster.ToContract();
-
+                    contract.TraktPoster = (parentImage as Trakt_ImagePoster)?.ToContract();
                     break;
             }
 
             return contract;
+        }
+
+        public Contract_AniDB_Anime_DefaultImage ToContract(ISessionWrapper session)
+        {
+            JMMImageType imgType = (JMMImageType)ImageParentType;
+            IImageEntity parentImage = null;
+
+            switch (imgType)
+            {
+                case JMMImageType.TvDB_Banner:
+                    TvDB_ImageWideBannerRepository repBanners = new TvDB_ImageWideBannerRepository();
+
+                    parentImage = repBanners.GetByID(session, ImageParentID);
+                    break;
+                case JMMImageType.TvDB_Cover:
+                    TvDB_ImagePosterRepository repPosters = new TvDB_ImagePosterRepository();
+
+                    parentImage = repPosters.GetByID(session, ImageParentID);
+                    break;
+                case JMMImageType.TvDB_FanArt:
+                    TvDB_ImageFanartRepository repFanart = new TvDB_ImageFanartRepository();
+
+                    parentImage = repFanart.GetByID(session, ImageParentID);
+                    break;
+                case JMMImageType.MovieDB_Poster:
+                    MovieDB_PosterRepository repMoviePosters = new MovieDB_PosterRepository();
+
+                    parentImage = repMoviePosters.GetByID(session, ImageParentID);
+                    break;
+                case JMMImageType.MovieDB_FanArt:
+                    MovieDB_FanartRepository repMovieFanart = new MovieDB_FanartRepository();
+
+                    parentImage = repMovieFanart.GetByID(session, ImageParentID);
+                    break;
+                case JMMImageType.Trakt_Fanart:
+                    Trakt_ImageFanartRepository repTraktFanart = new Trakt_ImageFanartRepository();
+                    parentImage = repTraktFanart.GetByID(session, ImageParentID);
+                    break;
+                case JMMImageType.Trakt_Poster:
+                    Trakt_ImagePosterRepository repTraktPoster = new Trakt_ImagePosterRepository();
+
+                    parentImage = repTraktPoster.GetByID(session, ImageParentID);
+                    break;
+            }
+
+            return ToContract(parentImage);
         }
     }
 }

--- a/JMMServer/Entities/AniDB_Character.cs
+++ b/JMMServer/Entities/AniDB_Character.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using AniDBAPI;
 using JMMContracts;
@@ -69,26 +70,33 @@ namespace JMMServer.Entities
             }
         }
 
-        public Contract_AniDB_Character ToContract(AniDB_Anime_Character charRel)
+        public Contract_AniDB_Character ToContract(string charType, AniDB_Seiyuu seiyuu)
         {
-            Contract_AniDB_Character contract = new Contract_AniDB_Character();
+            var contract = new Contract_AniDB_Character
+                {
+                    AniDB_CharacterID = AniDB_CharacterID,
+                    CharID = CharID,
+                    PicName = PicName,
+                    CreatorListRaw = CreatorListRaw,
+                    CharName = CharName,
+                    CharKanjiName = CharKanjiName,
+                    CharDescription = CharDescription,
+                    CharType = charType
+                };
 
-            contract.AniDB_CharacterID = this.AniDB_CharacterID;
-            contract.CharID = this.CharID;
-            contract.PicName = this.PicName;
-            contract.CreatorListRaw = this.CreatorListRaw;
-            contract.CharName = this.CharName;
-            contract.CharKanjiName = this.CharKanjiName;
-            contract.CharDescription = this.CharDescription;
-
-            contract.CharType = charRel.CharType;
-
-            contract.Seiyuu = null;
-            AniDB_Seiyuu seiyuu = this.GetSeiyuu();
             if (seiyuu != null)
+            {
                 contract.Seiyuu = seiyuu.ToContract();
+            }
 
             return contract;
+        }
+
+        public Contract_AniDB_Character ToContract(string charType)
+        {
+            AniDB_Seiyuu seiyuu = GetSeiyuu();
+
+            return ToContract(charType, seiyuu);
         }
 
         public MetroContract_AniDB_Character ToContractMetro(ISession session, AniDB_Anime_Character charRel)

--- a/JMMServer/Entities/AnimeEpisode.cs
+++ b/JMMServer/Entities/AnimeEpisode.cs
@@ -7,6 +7,7 @@ using JMMContracts;
 using JMMContracts.PlexAndKodi;
 using JMMServer.LZ4;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using Stream = JMMContracts.PlexAndKodi.Stream;
 
@@ -97,11 +98,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAnimeSeries(session);
+                return GetAnimeSeries(session.Wrap());
             }
         }
 
-        public AnimeSeries GetAnimeSeries(ISession session)
+        public AnimeSeries GetAnimeSeries(ISessionWrapper session)
         {
             AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
             return repSeries.GetByID(session, this.AnimeSeriesID);

--- a/JMMServer/Entities/AnimeGroup.cs
+++ b/JMMServer/Entities/AnimeGroup.cs
@@ -8,6 +8,7 @@ using JMMContracts;
 using JMMContracts.PlexAndKodi;
 using JMMServer.LZ4;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 
@@ -74,11 +75,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetPosterPathNoBlanks(session);
+                return GetPosterPathNoBlanks(session.Wrap());
             }
         }
 
-        public string GetPosterPathNoBlanks(ISession session)
+        public string GetPosterPathNoBlanks(ISessionWrapper session)
         {
             List<string> allPosters = GetPosterFilenames(session);
             string posterName = "";
@@ -96,11 +97,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetPosterFilenames(session);
+                return GetPosterFilenames(session.Wrap());
             }
         }
 
-        private List<string> GetPosterFilenames(ISession session)
+        private List<string> GetPosterFilenames(ISessionWrapper session)
         {
             List<string> allPosters = new List<string>();
 
@@ -200,11 +201,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetRelatedGroupsFromAnimeID(session, animeid, forceRecursive);
+                return GetRelatedGroupsFromAnimeID(session.Wrap(), animeid, forceRecursive);
             }
         }
 
-        public static List<AnimeGroup> GetRelatedGroupsFromAnimeID(ISession session, int animeid,
+        public static List<AnimeGroup> GetRelatedGroupsFromAnimeID(ISessionWrapper session, int animeid,
             bool forceRecursive = false)
         {
             AniDB_AnimeRepository repAniAnime = new AniDB_AnimeRepository();
@@ -471,11 +472,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetChildGroups(session);
+                return GetChildGroups(session.Wrap());
             }
         }
 
-        public List<AnimeGroup> GetChildGroups(ISession session)
+        public List<AnimeGroup> GetChildGroups(ISessionWrapper session)
         {
             AnimeGroupRepository repGroups = new AnimeGroupRepository();
             return repGroups.GetByParentID(session, this.AnimeGroupID);
@@ -496,11 +497,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAllChildGroups(session);
+                return GetAllChildGroups(session.Wrap());
             }
         }
 
-        public List<AnimeGroup> GetAllChildGroups(ISession session)
+        public List<AnimeGroup> GetAllChildGroups(ISessionWrapper session)
         {
             List<AnimeGroup> grpList = new List<AnimeGroup>();
             AnimeGroup.GetAnimeGroupsRecursive(session, this.AnimeGroupID, ref grpList);
@@ -523,11 +524,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetSeries(session);
+                return GetSeries(session.Wrap());
             }
         }
 
-        public List<AnimeSeries> GetSeries(ISession session)
+        public List<AnimeSeries> GetSeries(ISessionWrapper session)
         {
             AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
             List<AnimeSeries> seriesList = repSeries.GetByGroupID(this.AnimeGroupID);
@@ -561,11 +562,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAllSeries(session, skipSorting);
+                return GetAllSeries(session.Wrap(), skipSorting);
             }
         }
 
-        public List<AnimeSeries> GetAllSeries(ISession session, bool skipSorting=false)
+        public List<AnimeSeries> GetAllSeries(ISessionWrapper session, bool skipSorting = false)
         {
             List<AnimeSeries> seriesList = new List<AnimeSeries>();
             AnimeGroup.GetAnimeSeriesRecursive(session, this.AnimeGroupID, ref seriesList);
@@ -600,10 +601,12 @@ namespace JMMServer.Entities
 
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
+
                     // get a list of all the unique tags for this all the series in this group
                     foreach (AnimeSeries ser in GetAllSeries())
                     {
-                        foreach (AniDB_Anime_Tag aac in ser.GetAnime().GetAnimeTags(session))
+                        foreach (AniDB_Anime_Tag aac in ser.GetAnime().GetAnimeTags(sessionWrapper))
                         {
                             if (!animeTagIDs.Contains(aac.AniDB_Anime_TagID))
                             {
@@ -616,7 +619,7 @@ namespace JMMServer.Entities
                     AniDB_TagRepository repTag = new AniDB_TagRepository();
                     foreach (AniDB_Anime_Tag animeTag in animeTags.OrderByDescending(a=>a.Weight))
                     {
-                        AniDB_Tag tag = repTag.GetByTagID(animeTag.TagID, session);
+                        AniDB_Tag tag = repTag.GetByTagID(animeTag.TagID, sessionWrapper);
                         if (tag != null) tags.Add(tag);
                     }
                 }
@@ -981,7 +984,7 @@ namespace JMMServer.Entities
             return h;
         }
 
-        public HashSet<GroupFilterConditionType> UpdateContract(ISession session, bool updatestats)
+        public HashSet<GroupFilterConditionType> UpdateContract(ISessionWrapper session, bool updatestats)
         {
             Contract_AnimeGroup contract = (Contract_AnimeGroup) Contract?.DeepCopy();
             if (contract == null)
@@ -1290,7 +1293,7 @@ namespace JMMServer.Entities
         }
 
 
-        public static void GetAnimeGroupsRecursive(ISession session, int animeGroupID, ref List<AnimeGroup> groupList)
+        public static void GetAnimeGroupsRecursive(ISessionWrapper session, int animeGroupID, ref List<AnimeGroup> groupList)
         {
             AnimeGroupRepository rep = new AnimeGroupRepository();
             AnimeGroup grp = rep.GetByID(session, animeGroupID);
@@ -1305,7 +1308,7 @@ namespace JMMServer.Entities
             }
         }
 
-        public static void GetAnimeSeriesRecursive(ISession session, int animeGroupID, ref List<AnimeSeries> seriesList)
+        public static void GetAnimeSeriesRecursive(ISessionWrapper session, int animeGroupID, ref List<AnimeSeries> seriesList)
         {
             AnimeGroupRepository rep = new AnimeGroupRepository();
             AnimeGroup grp = rep.GetByID(session, animeGroupID);

--- a/JMMServer/Entities/AnimeGroup_User.cs
+++ b/JMMServer/Entities/AnimeGroup_User.cs
@@ -4,6 +4,7 @@ using JMMContracts.PlexAndKodi;
 using JMMServer.LZ4;
 using JMMServer.PlexAndKodi;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NLog;
 
 namespace JMMServer.Entities
@@ -128,12 +129,13 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
+                ISessionWrapper sessionWrapper = session.Wrap();
                 AnimeGroupRepository repo = new AnimeGroupRepository();
                 AnimeGroup grp = repo.GetByID(AnimeGroupID);
                 if (grp == null)
                     return;
-                List<AnimeSeries> series = grp.GetAllSeries(session);
-                PlexContract = Helper.GenerateFromAnimeGroup(session, grp, JMMUserID, series);
+                List<AnimeSeries> series = grp.GetAllSeries(sessionWrapper);
+                PlexContract = Helper.GenerateFromAnimeGroup(sessionWrapper, grp, JMMUserID, series);
             }
         }
 

--- a/JMMServer/Entities/AnimeSeries.cs
+++ b/JMMServer/Entities/AnimeSeries.cs
@@ -7,6 +7,7 @@ using JMMServer.Commands;
 using JMMServer.ImageDownload;
 using JMMServer.LZ4;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 using NutzCode.InMemoryIndex;
@@ -79,11 +80,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetSeriesName(session);
+                return GetSeriesName(session.Wrap());
             }
         }
 
-        public string GetSeriesName(ISession session)
+        public string GetSeriesName(ISessionWrapper session)
         {
             string seriesName = "";
             if (!string.IsNullOrEmpty(SeriesNameOverride))
@@ -185,11 +186,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAnimeEpisodes(session);
+                return GetAnimeEpisodes(session.Wrap());
             }
         }
 
-        public List<AnimeEpisode> GetAnimeEpisodes(ISession session)
+        public List<AnimeEpisode> GetAnimeEpisodes(ISessionWrapper session)
         {
             AnimeEpisodeRepository repEpisodes = new AnimeEpisodeRepository();
             return repEpisodes.GetBySeriesID(session, AnimeSeriesID);
@@ -240,11 +241,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetCrossRefTvDBV2(session);
+                return GetCrossRefTvDBV2(session.Wrap());
             }
         }
 
-        public List<CrossRef_AniDB_TvDBV2> GetCrossRefTvDBV2(ISession session)
+        public List<CrossRef_AniDB_TvDBV2> GetCrossRefTvDBV2(ISessionWrapper session)
         {
             CrossRef_AniDB_TvDBV2Repository repCrossRef = new CrossRef_AniDB_TvDBV2Repository();
             return repCrossRef.GetByAnimeID(session, this.AniDB_ID);
@@ -254,11 +255,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBSeries(session);
+                return GetTvDBSeries(session.Wrap());
             }
         }
 
-        public List<TvDB_Series> GetTvDBSeries(ISession session)
+        public List<TvDB_Series> GetTvDBSeries(ISessionWrapper session)
         {
             List<TvDB_Series> sers = new List<TvDB_Series>();
 
@@ -427,11 +428,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAnime(session);
+                return GetAnime(session.Wrap());
             }
         }
 
-        public AniDB_Anime GetAnime(ISession session)
+        public AniDB_Anime GetAnime(ISessionWrapper session)
         {
             AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
             AniDB_Anime anidb_anime = repAnime.GetByAnimeID(session, this.AniDB_ID);
@@ -488,10 +489,11 @@ namespace JMMServer.Entities
 
         public void CreateAnimeEpisodes(ISession session)
         {
-            AniDB_Anime anime = GetAnime(session);
+            ISessionWrapper sessionWrapper = session.Wrap();
+            AniDB_Anime anime = GetAnime(session.Wrap());
             if (anime == null) return;
 
-            foreach (AniDB_Episode ep in anime.GetAniDBEpisodes(session))
+            foreach (AniDB_Episode ep in anime.GetAniDBEpisodes(sessionWrapper))
             {
                 ep.CreateAnimeEpisode(session, this.AnimeSeriesID);
             }

--- a/JMMServer/Entities/CrossRef_AniDB_Other.cs
+++ b/JMMServer/Entities/CrossRef_AniDB_Other.cs
@@ -1,5 +1,6 @@
 ﻿using JMMContracts;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 
 namespace JMMServer.Entities
@@ -16,11 +17,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetMovieDB_Movie(session);
+                return GetMovieDB_Movie(session.Wrap());
             }
         }
 
-        public MovieDB_Movie GetMovieDB_Movie(ISession session)
+        public MovieDB_Movie GetMovieDB_Movie(ISessionWrapper session)
         {
             if (CrossRefType != (int) JMMServer.CrossRefType.MovieDB)
                 return null;

--- a/JMMServer/Entities/CrossRef_AniDB_TvDB.cs
+++ b/JMMServer/Entities/CrossRef_AniDB_TvDB.cs
@@ -1,5 +1,6 @@
 ﻿using JMMContracts;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 
 namespace JMMServer.Entities
@@ -17,11 +18,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBSeries(session);
+                return GetTvDBSeries(session.Wrap());
             }
         }
 
-        public TvDB_Series GetTvDBSeries(ISession session)
+        public TvDB_Series GetTvDBSeries(ISessionWrapper session)
         {
             TvDB_SeriesRepository repTvSeries = new TvDB_SeriesRepository();
             return repTvSeries.GetByTvDBID(session, TvDBID);

--- a/JMMServer/Entities/CrossRef_AniDB_TvDBV2.cs
+++ b/JMMServer/Entities/CrossRef_AniDB_TvDBV2.cs
@@ -1,5 +1,7 @@
-﻿using JMMContracts;
+﻿using System;
+using JMMContracts;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 
 namespace JMMServer.Entities
@@ -22,11 +24,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetTvDBSeries(session);
+                return GetTvDBSeries(session.Wrap());
             }
         }
 
-        public TvDB_Series GetTvDBSeries(ISession session)
+        public TvDB_Series GetTvDBSeries(ISessionWrapper session)
         {
             TvDB_SeriesRepository repTvSeries = new TvDB_SeriesRepository();
             return repTvSeries.GetByTvDBID(session, TvDBID);

--- a/JMMServer/Entities/IImageEntity.cs
+++ b/JMMServer/Entities/IImageEntity.cs
@@ -1,0 +1,6 @@
+﻿namespace JMMServer.Entities
+{
+    public interface IImageEntity
+    {
+    }
+}

--- a/JMMServer/Entities/MovieDB_Fanart.cs
+++ b/JMMServer/Entities/MovieDB_Fanart.cs
@@ -6,7 +6,7 @@ using NLog;
 
 namespace JMMServer.Entities
 {
-    public class MovieDB_Fanart
+    public class MovieDB_Fanart : IImageEntity
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/JMMServer/Entities/MovieDB_Poster.cs
+++ b/JMMServer/Entities/MovieDB_Poster.cs
@@ -6,7 +6,7 @@ using NLog;
 
 namespace JMMServer.Entities
 {
-    public class MovieDB_Poster
+    public class MovieDB_Poster : IImageEntity
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/JMMServer/Entities/Trakt_ImageFanart.cs
+++ b/JMMServer/Entities/Trakt_ImageFanart.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace JMMServer.Entities
 {
-    public class Trakt_ImageFanart
+    public class Trakt_ImageFanart : IImageEntity
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/JMMServer/Entities/Trakt_ImagePoster.cs
+++ b/JMMServer/Entities/Trakt_ImagePoster.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace JMMServer.Entities
 {
-    public class Trakt_ImagePoster
+    public class Trakt_ImagePoster : IImageEntity
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/JMMServer/Entities/TvDB_ImageFanart.cs
+++ b/JMMServer/Entities/TvDB_ImageFanart.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace JMMServer.Entities
 {
-    public class TvDB_ImageFanart
+    public class TvDB_ImageFanart : IImageEntity
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/JMMServer/Entities/TvDB_ImagePoster.cs
+++ b/JMMServer/Entities/TvDB_ImagePoster.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace JMMServer.Entities
 {
-    public class TvDB_ImagePoster
+    public class TvDB_ImagePoster : IImageEntity
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/JMMServer/Entities/TvDB_ImageWideBanner.cs
+++ b/JMMServer/Entities/TvDB_ImageWideBanner.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace JMMServer.Entities
 {
-    public class TvDB_ImageWideBanner
+    public class TvDB_ImageWideBanner : IImageEntity
     {
         private static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/JMMServer/Entities/VideoLocal.cs
+++ b/JMMServer/Entities/VideoLocal.cs
@@ -21,6 +21,7 @@ using Path = Pri.LongPath.Path;
 using Directory = Pri.LongPath.Directory;
 using File = Pri.LongPath.File;
 using FileInfo = Pri.LongPath.FileInfo;
+using JMMServer.Repositories.NHibernate;
 
 namespace JMMServer.Entities
 {
@@ -139,11 +140,11 @@ namespace JMMServer.Entities
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetAniDBFile(session);
+                return GetAniDBFile(session.Wrap());
             }
         }
 
-        public AniDB_File GetAniDBFile(ISession session)
+        public AniDB_File GetAniDBFile(ISessionWrapper session)
         {
             AniDB_FileRepository repAniFile = new AniDB_FileRepository();
             return repAniFile.GetByHash(session, Hash);

--- a/JMMServer/Importer.cs
+++ b/JMMServer/Importer.cs
@@ -13,6 +13,7 @@ using JMMServer.Providers.MyAnimeList;
 using JMMServer.Providers.TraktTV;
 using JMMServer.Providers.TvDB;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NLog;
 using CrossRef_File_Episode = JMMServer.Entities.CrossRef_File_Episode;
 
@@ -143,6 +144,7 @@ namespace JMMServer
             AniDB_FileRepository repFiles=new AniDB_FileRepository();
             using (var session = JMMService.SessionFactory.OpenSession())
             {
+                ISessionWrapper sessionWrapper = session.Wrap();
                 List<VideoLocal> allfiles = repVidLocals.GetAll().ToList();
                 List<VideoLocal> missfiles = allfiles.Where(
                             a =>
@@ -153,7 +155,7 @@ namespace JMMServer
                 //Check if we can populate md5,sha and crc from AniDB_Files
                 foreach (VideoLocal v in missfiles.ToList())
                 {
-                    AniDB_File file = repFiles.GetByHash(session,v.ED2KHash);
+                    AniDB_File file = repFiles.GetByHash(sessionWrapper,v.ED2KHash);
                     if (file != null)
                     {
                         if (!string.IsNullOrEmpty(file.CRC) && !string.IsNullOrEmpty(file.SHA1) &&

--- a/JMMServer/JMMServer.csproj
+++ b/JMMServer/JMMServer.csproj
@@ -259,9 +259,13 @@
     <Compile Include="AniDB_API\UpdatesCollection.cs" />
     <Compile Include="AniDB_API\Utils.cs" />
     <Compile Include="AniDB_API\XMLBase.cs" />
+    <Compile Include="Collections\EmptyLookup.cs" />
+    <Compile Include="Collections\EnumerableExtensions.cs" />
+    <Compile Include="Collections\LazyLookup.cs" />
     <Compile Include="Commands\TvDB\CommandRequest_LinkAniDBTvDB.cs" />
     <Compile Include="Databases\DatabaseFixes.cs" />
     <Compile Include="Databases\IDatabase.cs" />
+    <Compile Include="Entities\IImageEntity.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="LZ4\CompressionHelper.cs" />
     <Compile Include="LZ4\LZ4Codec.cs" />
@@ -539,6 +543,11 @@
     <Compile Include="Repositories\CrossRef_CustomTagRepository.cs" />
     <Compile Include="Repositories\CustomTagRepository.cs" />
     <Compile Include="Repositories\FileFfdshowPresetRepository.cs" />
+    <Compile Include="Repositories\NHibernate\ISessionWrapper.cs" />
+    <Compile Include="Repositories\NHibernate\SessionWrapper.cs" />
+    <Compile Include="Repositories\NHibernate\SessionExtensions.cs" />
+    <Compile Include="Repositories\NHibernate\StatelessSessionWrapper.cs" />
+    <Compile Include="Repositories\NHibernate\StatelessSessionExtensions.cs" />
     <Compile Include="Repositories\PlaylistRepository.cs" />
     <Compile Include="Repositories\RenameScriptRepository.cs" />
     <Compile Include="Security\CRC32.cs" />

--- a/JMMServer/JMMServiceImplementationMetro.cs
+++ b/JMMServer/JMMServiceImplementationMetro.cs
@@ -13,6 +13,7 @@ using JMMServer.Providers.TraktTV;
 using JMMServer.Providers.TraktTV.Contracts;
 using JMMServer.Providers.TvDB;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NLog;
 
 namespace JMMServer
@@ -79,9 +80,10 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
 
-                    AniDB_Anime anime = repAnime.GetByAnimeID(session, animeID);
+                    AniDB_Anime anime = repAnime.GetByAnimeID(sessionWrapper, animeID);
                     if (anime == null) return null;
 
                     //AniDB
@@ -100,7 +102,7 @@ namespace JMMServer
                     }
 
                     // TvDB
-                    List<CrossRef_AniDB_TvDBV2> tvdbRef = anime.GetCrossRefTvDBV2(session);
+                    List<CrossRef_AniDB_TvDBV2> tvdbRef = anime.GetCrossRefTvDBV2(sessionWrapper);
                     if (tvdbRef != null && tvdbRef.Count > 0)
                     {
                         contract.TvDB_ID = tvdbRef[0].TvDBID.ToString();
@@ -181,13 +183,14 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AnimeEpisodeRepository repEps = new AnimeEpisodeRepository();
                     AnimeEpisode_UserRepository repEpUser = new AnimeEpisode_UserRepository();
                     AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
                     JMMUserRepository repUsers = new JMMUserRepository();
                     VideoLocalRepository repVids = new VideoLocalRepository();
 
-                    JMMUser user = repUsers.GetByID(session, jmmuserID);
+                    JMMUser user = repUsers.GetByID(sessionWrapper, jmmuserID);
                     if (user == null) return retEps;
 
                     string sql = "Select ae.AnimeSeriesID, max(vl.DateTimeCreated) as MaxDate " +
@@ -203,7 +206,7 @@ namespace JMMServer
                     {
                         int animeSeriesID = int.Parse(res[0].ToString());
 
-                        AnimeSeries ser = repSeries.GetByID(session, animeSeriesID);
+                        AnimeSeries ser = repSeries.GetByID(sessionWrapper, animeSeriesID);
                         if (ser == null) continue;
 
                         if (!user.AllowedSeries(session, ser)) continue;
@@ -242,13 +245,14 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AnimeEpisodeRepository repEps = new AnimeEpisodeRepository();
                     AnimeEpisode_UserRepository repEpUser = new AnimeEpisode_UserRepository();
                     AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
                     JMMUserRepository repUsers = new JMMUserRepository();
                     VideoLocalRepository repVids = new VideoLocalRepository();
 
-                    JMMUser user = repUsers.GetByID(session, jmmuserID);
+                    JMMUser user = repUsers.GetByID(sessionWrapper, jmmuserID);
                     if (user == null) return retAnime;
 
                     string sql = "Select ae.AnimeSeriesID, max(vl.DateTimeCreated) as MaxDate " +
@@ -264,7 +268,7 @@ namespace JMMServer
                     {
                         int animeSeriesID = int.Parse(res[0].ToString());
 
-                        AnimeSeries ser = repSeries.GetByID(session, animeSeriesID);
+                        AnimeSeries ser = repSeries.GetByID(sessionWrapper, animeSeriesID);
                         if (ser == null) continue;
 
                         if (!user.AllowedSeries(session, ser)) continue;
@@ -280,11 +284,11 @@ namespace JMMServer
                         Contract_AnimeEpisode epContract = eps[0].GetUserContract(jmmuserID);
                         if (epContract != null)
                         {
-                            AniDB_Anime anidb_anime = ser.GetAnime(session);
+                            AniDB_Anime anidb_anime = ser.GetAnime(sessionWrapper);
 
                             MetroContract_Anime_Summary summ = new MetroContract_Anime_Summary();
                             summ.AnimeID = ser.AniDB_ID;
-                            summ.AnimeName = ser.GetSeriesName(session);
+                            summ.AnimeName = ser.GetSeriesName(sessionWrapper);
                             summ.AnimeSeriesID = ser.AnimeSeriesID;
                             summ.BeginYear = anidb_anime.BeginYear;
                             summ.EndYear = anidb_anime.EndYear;
@@ -294,7 +298,7 @@ namespace JMMServer
                             else
                                 summ.UnwatchedEpisodeCount = 0;
 
-                            ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(session);
+                            ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                             summ.ImageType = (int) imgDet.ImageType;
                             summ.ImageID = imgDet.ImageID;
 
@@ -322,6 +326,7 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AnimeEpisodeRepository repEps = new AnimeEpisodeRepository();
                     AnimeSeriesRepository repAnimeSer = new AnimeSeriesRepository();
                     AnimeSeries_UserRepository repSeriesUser = new AnimeSeries_UserRepository();
@@ -329,7 +334,7 @@ namespace JMMServer
 
                     DateTime start = DateTime.Now;
 
-                    JMMUser user = repUsers.GetByID(session, jmmuserID);
+                    JMMUser user = repUsers.GetByID(sessionWrapper, jmmuserID);
                     if (user == null) return retAnime;
 
                     // get a list of series that is applicable
@@ -344,7 +349,7 @@ namespace JMMServer
                     {
                         start = DateTime.Now;
 
-                        AnimeSeries series = repAnimeSer.GetByID(session, userRecord.AnimeSeriesID);
+                        AnimeSeries series = repAnimeSer.GetByID(sessionWrapper, userRecord.AnimeSeriesID);
                         if (series == null) continue;
 
                         if (!user.AllowedSeries(session, series))
@@ -356,15 +361,15 @@ namespace JMMServer
 
                         AnimeSeries_User serUser = series.GetUserRecord(session, jmmuserID);
 
-                        Contract_AnimeEpisode ep = imp.GetNextUnwatchedEpisode(session, userRecord.AnimeSeriesID,
+                        Contract_AnimeEpisode ep = imp.GetNextUnwatchedEpisode(sessionWrapper, userRecord.AnimeSeriesID,
                             jmmuserID);
                         if (ep != null)
                         {
-                            AniDB_Anime anidb_anime = series.GetAnime(session);
+                            AniDB_Anime anidb_anime = series.GetAnime(sessionWrapper);
 
                             MetroContract_Anime_Summary summ = new MetroContract_Anime_Summary();
                             summ.AnimeID = series.AniDB_ID;
-                            summ.AnimeName = series.GetSeriesName(session);
+                            summ.AnimeName = series.GetSeriesName(sessionWrapper);
                             summ.AnimeSeriesID = series.AnimeSeriesID;
                             summ.BeginYear = anidb_anime.BeginYear;
                             summ.EndYear = anidb_anime.EndYear;
@@ -375,7 +380,7 @@ namespace JMMServer
                             else
                                 summ.UnwatchedEpisodeCount = 0;
 
-                            ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(session);
+                            ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                             summ.ImageType = (int) imgDet.ImageType;
                             summ.ImageID = imgDet.ImageID;
 
@@ -409,10 +414,11 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     GroupFilterRepository repGF = new GroupFilterRepository();
                     AnimeGroup_UserRepository repGU = new AnimeGroup_UserRepository();
                     JMMUserRepository repUsers = new JMMUserRepository();
-                    JMMUser user = repUsers.GetByID(session, jmmuserID);
+                    JMMUser user = repUsers.GetByID(sessionWrapper, jmmuserID);
                     if (user == null) return retAnime;
 
                     // find the locked Continue Watching Filter
@@ -451,14 +457,14 @@ namespace JMMServer
 
                             AnimeSeries_User serUser = ser.GetUserRecord(session, jmmuserID);
 
-                            Contract_AnimeEpisode ep = imp.GetNextUnwatchedEpisode(session, ser.AnimeSeriesID, jmmuserID);
+                            Contract_AnimeEpisode ep = imp.GetNextUnwatchedEpisode(sessionWrapper, ser.AnimeSeriesID, jmmuserID);
                             if (ep != null)
                             {
-                                AniDB_Anime anidb_anime = ser.GetAnime(session);
+                                AniDB_Anime anidb_anime = ser.GetAnime(sessionWrapper);
 
                                 MetroContract_Anime_Summary summ = new MetroContract_Anime_Summary();
                                 summ.AnimeID = ser.AniDB_ID;
-                                summ.AnimeName = ser.GetSeriesName(session);
+                                summ.AnimeName = ser.GetSeriesName(sessionWrapper);
                                 summ.AnimeSeriesID = ser.AnimeSeriesID;
                                 summ.BeginYear = anidb_anime.BeginYear;
                                 summ.EndYear = anidb_anime.EndYear;
@@ -469,7 +475,7 @@ namespace JMMServer
                                 else
                                     summ.UnwatchedEpisodeCount = 0;
 
-                                ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(session);
+                                ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                                 summ.ImageType = (int) imgDet.ImageType;
                                 summ.ImageID = imgDet.ImageID;
 
@@ -502,12 +508,12 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
                     JMMUserRepository repUsers = new JMMUserRepository();
                     AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
 
-
-                    JMMUser user = repUsers.GetByID(session, jmmuserID);
+                    JMMUser user = repUsers.GetByID(sessionWrapper, jmmuserID);
                     if (user == null) return retAnime;
 
                     DateTime? startDate = Utils.GetAniDBDateAsDate(startDateSecs);
@@ -526,7 +532,7 @@ namespace JMMServer
                         summ.AnimeID = anidb_anime.AnimeID;
                         if (ser != null)
                         {
-                            summ.AnimeName = ser.GetSeriesName(session);
+                            summ.AnimeName = ser.GetSeriesName(sessionWrapper);
                             summ.AnimeSeriesID = ser.AnimeSeriesID;
                         }
                         else
@@ -536,9 +542,9 @@ namespace JMMServer
                         }
                         summ.BeginYear = anidb_anime.BeginYear;
                         summ.EndYear = anidb_anime.EndYear;
-                        summ.PosterName = anidb_anime.GetDefaultPosterPathNoBlanks(session);
+                        summ.PosterName = anidb_anime.GetDefaultPosterPathNoBlanks(sessionWrapper);
 
-                        ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(session);
+                        ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                         summ.ImageType = (int) imgDet.ImageType;
                         summ.ImageID = imgDet.ImageID;
 
@@ -562,12 +568,12 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
                     JMMUserRepository repUsers = new JMMUserRepository();
                     AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
 
-
-                    JMMUser user = repUsers.GetByID(session, jmmuserID);
+                    JMMUser user = repUsers.GetByID(sessionWrapper, jmmuserID);
                     if (user == null) return retAnime;
 
 
@@ -584,7 +590,7 @@ namespace JMMServer
                         summ.AnimeID = anidb_anime.AnimeID;
                         if (ser != null)
                         {
-                            summ.AnimeName = ser.GetSeriesName(session);
+                            summ.AnimeName = ser.GetSeriesName(sessionWrapper);
                             summ.AnimeSeriesID = ser.AnimeSeriesID;
                         }
                         else
@@ -594,9 +600,9 @@ namespace JMMServer
                         }
                         summ.BeginYear = anidb_anime.BeginYear;
                         summ.EndYear = anidb_anime.EndYear;
-                        summ.PosterName = anidb_anime.GetDefaultPosterPathNoBlanks(session);
+                        summ.PosterName = anidb_anime.GetDefaultPosterPathNoBlanks(sessionWrapper);
 
-                        ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(session);
+                        ImageDetails imgDet = anidb_anime.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                         summ.ImageType = (int) imgDet.ImageType;
                         summ.ImageID = imgDet.ImageID;
 
@@ -619,19 +625,20 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
 
-                    AniDB_Anime anime = repAnime.GetByAnimeID(session, animeID);
+                    AniDB_Anime anime = repAnime.GetByAnimeID(sessionWrapper, animeID);
                     if (anime == null) return null;
 
-                    AnimeSeries ser = repSeries.GetByAnimeID(session, animeID);
+                    AnimeSeries ser = repSeries.GetByAnimeID(sessionWrapper, animeID);
 
                     MetroContract_Anime_Detail ret = new MetroContract_Anime_Detail();
                     ret.AnimeID = anime.AnimeID;
 
                     if (ser != null)
-                        ret.AnimeName = ser.GetSeriesName(session);
+                        ret.AnimeName = ser.GetSeriesName(sessionWrapper);
                     else
                         ret.AnimeName = anime.MainTitle;
 
@@ -643,11 +650,11 @@ namespace JMMServer
                     ret.BeginYear = anime.BeginYear;
                     ret.EndYear = anime.EndYear;
 
-                    ImageDetails imgDet = anime.GetDefaultPosterDetailsNoBlanks(session);
+                    ImageDetails imgDet = anime.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                     ret.PosterImageType = (int) imgDet.ImageType;
                     ret.PosterImageID = imgDet.ImageID;
 
-                    ImageDetails imgDetFan = anime.GetDefaultFanartDetailsNoBlanks(session);
+                    ImageDetails imgDetFan = anime.GetDefaultFanartDetailsNoBlanks(sessionWrapper);
                     if (imgDetFan != null)
                     {
                         ret.FanartImageType = (int) imgDetFan.ImageType;
@@ -688,10 +695,10 @@ namespace JMMServer
                         Dictionary<int, AnimeEpisode_User> dictEpUsers = new Dictionary<int, AnimeEpisode_User>();
                         foreach (
                             AnimeEpisode_User userRecord in
-                                repEpUser.GetByUserIDAndSeriesID(session, jmmuserID, ser.AnimeSeriesID))
+                                repEpUser.GetByUserIDAndSeriesID(sessionWrapper, jmmuserID, ser.AnimeSeriesID))
                             dictEpUsers[userRecord.AnimeEpisodeID] = userRecord;
 
-                        foreach (AnimeEpisode animeep in repEps.GetBySeriesID(session, ser.AnimeSeriesID))
+                        foreach (AnimeEpisode animeep in repEps.GetBySeriesID(sessionWrapper, ser.AnimeSeriesID))
                         {
                             if (!dictEpUsers.ContainsKey(animeep.AnimeEpisodeID))
                             {
@@ -705,7 +712,7 @@ namespace JMMServer
                         }
 
                         AniDB_EpisodeRepository repAniEps = new AniDB_EpisodeRepository();
-                        List<AniDB_Episode> aniEpList = repAniEps.GetByAnimeID(session, ser.AniDB_ID);
+                        List<AniDB_Episode> aniEpList = repAniEps.GetByAnimeID(sessionWrapper, ser.AniDB_ID);
                         Dictionary<int, AniDB_Episode> dictAniEps = new Dictionary<int, AniDB_Episode>();
                         foreach (AniDB_Episode aniep in aniEpList)
                             dictAniEps[aniep.EpisodeID] = aniep;
@@ -806,14 +813,15 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AnimeEpisodeRepository repEps = new AnimeEpisodeRepository();
                     AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
 
-                    AniDB_Anime anime = repAnime.GetByAnimeID(session, animeID);
+                    AniDB_Anime anime = repAnime.GetByAnimeID(sessionWrapper, animeID);
                     if (anime == null) return null;
 
-                    AnimeSeries ser = repSeries.GetByAnimeID(session, animeID);
+                    AnimeSeries ser = repSeries.GetByAnimeID(sessionWrapper, animeID);
 
                     MetroContract_Anime_Summary summ = new MetroContract_Anime_Summary();
                     summ.AnimeID = anime.AnimeID;
@@ -822,15 +830,15 @@ namespace JMMServer
 
                     summ.BeginYear = anime.BeginYear;
                     summ.EndYear = anime.EndYear;
-                    summ.PosterName = anime.GetDefaultPosterPathNoBlanks(session);
+                    summ.PosterName = anime.GetDefaultPosterPathNoBlanks(sessionWrapper);
 
-                    ImageDetails imgDet = anime.GetDefaultPosterDetailsNoBlanks(session);
+                    ImageDetails imgDet = anime.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                     summ.ImageType = (int) imgDet.ImageType;
                     summ.ImageID = imgDet.ImageID;
 
                     if (ser != null)
                     {
-                        summ.AnimeName = ser.GetSeriesName(session);
+                        summ.AnimeName = ser.GetSeriesName(sessionWrapper);
                         summ.AnimeSeriesID = ser.AnimeSeriesID;
                     }
 
@@ -1056,10 +1064,11 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AniDB_Anime_CharacterRepository repAnimeChar = new AniDB_Anime_CharacterRepository();
                     AniDB_CharacterRepository repChar = new AniDB_CharacterRepository();
 
-                    List<AniDB_Anime_Character> animeChars = repAnimeChar.GetByAnimeID(session, animeID);
+                    List<AniDB_Anime_Character> animeChars = repAnimeChar.GetByAnimeID(sessionWrapper, animeID);
                     if (animeChars == null || animeChars.Count == 0) return chars;
 
                     int cnt = 0;
@@ -1172,10 +1181,11 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AniDB_RecommendationRepository repBA = new AniDB_RecommendationRepository();
 
                     int cnt = 0;
-                    foreach (AniDB_Recommendation rec in repBA.GetByAnimeID(session, animeID))
+                    foreach (AniDB_Recommendation rec in repBA.GetByAnimeID(sessionWrapper, animeID))
                     {
                         MetroContract_Comment shout = new MetroContract_Comment();
 
@@ -1229,12 +1239,13 @@ namespace JMMServer
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
                     AniDB_AnimeRepository repAnime = new AniDB_AnimeRepository();
-                    AniDB_Anime anime = repAnime.GetByAnimeID(session, animeID);
+                    AniDB_Anime anime = repAnime.GetByAnimeID(sessionWrapper, animeID);
                     if (anime == null) return retAnime;
 
                     JMMUserRepository repUsers = new JMMUserRepository();
-                    JMMUser juser = repUsers.GetByID(session, jmmuserID);
+                    JMMUser juser = repUsers.GetByID(sessionWrapper, jmmuserID);
                     if (juser == null) return retAnime;
 
                     AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
@@ -1268,13 +1279,13 @@ namespace JMMServer
 
                         summ.RelationshipType = link.RelationType;
 
-                        ImageDetails imgDet = animeLink.GetDefaultPosterDetailsNoBlanks(session);
+                        ImageDetails imgDet = animeLink.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                         summ.ImageType = (int) imgDet.ImageType;
                         summ.ImageID = imgDet.ImageID;
 
                         if (ser != null)
                         {
-                            summ.AnimeName = ser.GetSeriesName(session);
+                            summ.AnimeName = ser.GetSeriesName(sessionWrapper);
                             summ.AnimeSeriesID = ser.AnimeSeriesID;
                         }
 
@@ -1284,7 +1295,7 @@ namespace JMMServer
                     // now get similar anime
                     foreach (AniDB_Anime_Similar link in anime.GetSimilarAnime(session))
                     {
-                        AniDB_Anime animeLink = repAnime.GetByAnimeID(session, link.SimilarAnimeID);
+                        AniDB_Anime animeLink = repAnime.GetByAnimeID(sessionWrapper, link.SimilarAnimeID);
 
                         if (animeLink == null)
                         {
@@ -1297,7 +1308,7 @@ namespace JMMServer
                         if (!juser.AllowedAnime(animeLink)) continue;
 
                         // check if this anime has a series
-                        AnimeSeries ser = repSeries.GetByAnimeID(session, link.SimilarAnimeID);
+                        AnimeSeries ser = repSeries.GetByAnimeID(sessionWrapper, link.SimilarAnimeID);
 
                         MetroContract_Anime_Summary summ = new MetroContract_Anime_Summary();
                         summ.AnimeID = animeLink.AnimeID;
@@ -1310,13 +1321,13 @@ namespace JMMServer
 
                         summ.RelationshipType = "Recommendation";
 
-                        ImageDetails imgDet = animeLink.GetDefaultPosterDetailsNoBlanks(session);
+                        ImageDetails imgDet = animeLink.GetDefaultPosterDetailsNoBlanks(sessionWrapper);
                         summ.ImageType = (int) imgDet.ImageType;
                         summ.ImageID = imgDet.ImageID;
 
                         if (ser != null)
                         {
-                            summ.AnimeName = ser.GetSeriesName(session);
+                            summ.AnimeName = ser.GetSeriesName(sessionWrapper);
                             summ.AnimeSeriesID = ser.AnimeSeriesID;
                         }
 

--- a/JMMServer/PlexAndKodi/CommonImplementation.cs
+++ b/JMMServer/PlexAndKodi/CommonImplementation.cs
@@ -14,6 +14,7 @@ using JMMServer.Entities;
 using JMMServer.PlexAndKodi.Kodi;
 using JMMServer.Properties;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NLog;
 using Directory = JMMContracts.PlexAndKodi.Directory;
 
@@ -168,12 +169,13 @@ namespace JMMServer.PlexAndKodi
             {
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
-                    var ret =
-                        new BaseObject(prov.NewMediaContainer(MediaContainerTypes.Show, "Playlists", true, true, info));
+                    var ret = new BaseObject(prov.NewMediaContainer(MediaContainerTypes.Show, "Playlists", true, true, info));
                     if (!ret.Init())
                         return new MediaContainer(); //Normal
                     var retPlaylists = new List<Video>();
                     var playlists = playlistRepository.GetAll();
+                    var sessionWrapper = session.Wrap();
+
                     foreach (var playlist in playlists)
                     {
                         var dir = new Directory();
@@ -184,10 +186,10 @@ namespace JMMServer.PlexAndKodi
                         var episodeID = -1;
                         if (int.TryParse(playlist.PlaylistItems.Split('|')[0].Split(';')[1], out episodeID))
                         {
-                            var anime = repo.GetByID(session, episodeID).GetAnimeSeries(session).GetAnime(session);
-                            dir.Thumb = anime?.GetDefaultPosterDetailsNoBlanks(session)?.GenPoster();
-                            dir.Art = anime?.GetDefaultFanartDetailsNoBlanks(session)?.GenArt();
-	                        dir.Banner = anime?.GetDefaultWideBannerDetailsNoBlanks(session)?.GenArt();
+                            var anime = repo.GetByID(session, episodeID).GetAnimeSeries(sessionWrapper).GetAnime(sessionWrapper);
+                            dir.Thumb = anime?.GetDefaultPosterDetailsNoBlanks(sessionWrapper)?.GenPoster();
+                            dir.Art = anime?.GetDefaultFanartDetailsNoBlanks(sessionWrapper)?.GenArt();
+                            dir.Banner = anime?.GetDefaultWideBannerDetailsNoBlanks(sessionWrapper)?.GenArt();
                         }
                         else
                         {
@@ -214,6 +216,8 @@ namespace JMMServer.PlexAndKodi
                     return new MediaContainer(); //Normal
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    var sessionWrapper = session.Wrap();
+
                     foreach (var item in playlistItems)
                     {
                         try
@@ -231,7 +235,7 @@ namespace JMMServer.PlexAndKodi
                                     e.GetUserContract(userid));
                             if (ep.Value != null && ep.Value.LocalFileCount == 0)
                                 continue;
-                            AnimeSeries ser = serRepo.GetByID(session, ep.Key.AnimeSeriesID);
+                            AnimeSeries ser = serRepo.GetByID(sessionWrapper, ep.Key.AnimeSeriesID);
                             if (ser == null)
                                 return new MediaContainer() {ErrorString="Invalid Series"};
                             Contract_AnimeSeries con = ser.GetUserContract(userid);
@@ -335,6 +339,7 @@ namespace JMMServer.PlexAndKodi
                 List<Video> dirs = new List<Video>();
                 AnimeEpisodeRepository epRepo = new AnimeEpisodeRepository();
                 AnimeSeriesRepository serRepo = new AnimeSeriesRepository();
+                ISessionWrapper sessionWrapper = session.Wrap();
 
                 AnimeEpisode e = epRepo.GetByID(session, id);
                 if (e == null)
@@ -347,10 +352,10 @@ namespace JMMServer.PlexAndKodi
                 AniDB_Episode aep = ep.Key.AniDB_Episode;
                 if (aep == null)
                     return new MediaContainer() {ErrorString = "Invalid Episode AniDB link not found"};
-                AnimeSeries ser = serRepo.GetByID(session, ep.Key.AnimeSeriesID);
+                AnimeSeries ser = serRepo.GetByID(sessionWrapper, ep.Key.AnimeSeriesID);
                 if (ser == null)
                     return new MediaContainer() {ErrorString = "Invalid Serie"};
-                AniDB_Anime anime = ser.GetAnime(session);
+                AniDB_Anime anime = ser.GetAnime(sessionWrapper);
                 Contract_AnimeSeries con = ser.GetUserContract(userid);
                 if (con == null)
                     return new MediaContainer() {ErrorString = "Invalid Serie, Contract not found"};
@@ -760,6 +765,8 @@ namespace JMMServer.PlexAndKodi
                     return rsp;
                 using (var session = JMMService.SessionFactory.OpenSession())
                 {
+                    ISessionWrapper sessionWrapper = session.Wrap();
+
                     if (vt == (int) enAniDBVoteType.Episode)
                     {
                         AnimeEpisodeRepository repEpisodes = new AnimeEpisodeRepository();
@@ -819,7 +826,7 @@ namespace JMMServer.PlexAndKodi
                     if (vt == (int) enAniDBVoteType.Anime)
                     {
                         AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
-                        AnimeSeries ser = repSeries.GetByID(session, objid);
+                        AnimeSeries ser = repSeries.GetByID(sessionWrapper, objid);
                         AniDB_Anime anime = ser.GetAnime();
                         if (anime == null)
                         {
@@ -1009,8 +1016,9 @@ namespace JMMServer.PlexAndKodi
             {
                 if (serieID == -1)
                     return new MediaContainer() { ErrorString = "Invalid Serie Id" };
+                ISessionWrapper sessionWrapper = session.Wrap();
                 AnimeSeriesRepository repSeries = new AnimeSeriesRepository();
-                AnimeSeries ser = repSeries.GetByID(session, serieID);
+                AnimeSeries ser = repSeries.GetByID(sessionWrapper, serieID);
                 if (ser == null)
                     return new MediaContainer() {ErrorString = "Invalid Series"};
                 Contract_AnimeSeries cseries = ser.GetUserContract(userid);
@@ -1019,7 +1027,7 @@ namespace JMMServer.PlexAndKodi
                 Video nv = ser.GetPlexContract(userid);
 
 
-                Dictionary<AnimeEpisode, Contract_AnimeEpisode> episodes = ser.GetAnimeEpisodes(session)
+                Dictionary<AnimeEpisode, Contract_AnimeEpisode> episodes = ser.GetAnimeEpisodes(sessionWrapper)
                     .ToDictionary(a => a, a => a.GetUserContract(userid));
                 episodes = episodes.Where(a => a.Value == null || a.Value.LocalFileCount > 0)
                     .ToDictionary(a => a.Key, a => a.Value);

--- a/JMMServer/PlexAndKodi/Helper.cs
+++ b/JMMServer/PlexAndKodi/Helper.cs
@@ -16,6 +16,7 @@ using JMMFileHelper.Subtitles;
 using JMMServer.Entities;
 using JMMServer.ImageDownload;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using Directory = JMMContracts.PlexAndKodi.Directory;
 using Stream = JMMContracts.PlexAndKodi.Stream;
@@ -600,11 +601,11 @@ namespace JMMServer.PlexAndKodi
 	    {
 		    using (var session = JMMService.SessionFactory.OpenSession())
 		    {
-			    return GetRandomBannerFromSeries(series, session);
+			    return GetRandomBannerFromSeries(series, session.Wrap());
 		    }
 	    }
 
-	    public static string GetRandomBannerFromSeries(List<AnimeSeries> series, ISession session)
+	    public static string GetRandomBannerFromSeries(List<AnimeSeries> series, ISessionWrapper session)
 	    {
 		    foreach (AnimeSeries ser in series.Randomize())
 		    {
@@ -637,11 +638,11 @@ namespace JMMServer.PlexAndKodi
 		{
 			using (var session = JMMService.SessionFactory.OpenSession())
 			{
-				return GetRandomFanartFromSeries(series, session);
+				return GetRandomFanartFromSeries(series, session.Wrap());
 			}
 		}
 
-        public static string GetRandomFanartFromSeries(List<AnimeSeries> series, ISession session)
+        public static string GetRandomFanartFromSeries(List<AnimeSeries> series, ISessionWrapper session)
         {
             foreach (AnimeSeries ser in series.Randomize())
             {
@@ -666,7 +667,7 @@ namespace JMMServer.PlexAndKodi
             return null;
         }
 
-        public static Video GenerateFromAnimeGroup(ISession session, AnimeGroup grp, int userid,
+        public static Video GenerateFromAnimeGroup(ISessionWrapper session, AnimeGroup grp, int userid,
             List<AnimeSeries> allSeries)
         {
             Contract_AnimeGroup cgrp = grp.GetUserContract(userid);
@@ -857,12 +858,13 @@ namespace JMMServer.PlexAndKodi
         {
             using (ISession session = JMMService.SessionFactory.OpenSession())
             {
+                ISessionWrapper sessionWrapper = session.Wrap();
                 Contract_AniDBAnime anime = ser.AniDBAnime.AniDBAnime;
                 p.Id = ser.AnimeSeriesID.ToString();
                 p.AnimeType = JMMContracts.PlexAndKodi.AnimeTypes.AnimeSerie.ToString();
                 if (ser.AniDBAnime.AniDBAnime.Restricted > 0)
                     p.ContentRating = "R";
-                p.Title = aser.GetSeriesName(session);
+                p.Title = aser.GetSeriesName(sessionWrapper);
                 p.Summary = SummaryFromAnimeContract(ser);
                 p.Type = "show";
                 p.AirDate = DateTime.MinValue;

--- a/JMMServer/Providers/MovieDB/MovieDBHelper.cs
+++ b/JMMServer/Providers/MovieDB/MovieDBHelper.cs
@@ -5,6 +5,7 @@ using System.Text;
 using JMMServer.Commands;
 using JMMServer.Entities;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 using TMDbLib.Client;
@@ -43,6 +44,7 @@ namespace JMMServer.Providers.MovieDB
             MovieDB_MovieRepository repMovies = new MovieDB_MovieRepository();
             MovieDB_FanartRepository repFanart = new MovieDB_FanartRepository();
             MovieDB_PosterRepository repPosters = new MovieDB_PosterRepository();
+            ISessionWrapper sessionWrapper = session.Wrap();
 
             // save to the DB
             MovieDB_Movie movie = repMovies.GetByOnlineID(searchResult.MovieID);
@@ -84,7 +86,7 @@ namespace JMMServer.Providers.MovieDB
             // download the posters
             if (ServerSettings.MovieDB_AutoPosters)
             {
-                foreach (MovieDB_Poster poster in repPosters.GetByMovieID(session, movie.MovieId))
+                foreach (MovieDB_Poster poster in repPosters.GetByMovieID(sessionWrapper, movie.MovieId))
                 {
                     if (numPostersDownloaded < ServerSettings.MovieDB_AutoPostersAmount)
                     {
@@ -113,7 +115,7 @@ namespace JMMServer.Providers.MovieDB
             // download the fanart
             if (ServerSettings.MovieDB_AutoFanart)
             {
-                foreach (MovieDB_Fanart fanart in repFanart.GetByMovieID(session, movie.MovieId))
+                foreach (MovieDB_Fanart fanart in repFanart.GetByMovieID(sessionWrapper, movie.MovieId))
                 {
                     if (numFanartDownloaded < ServerSettings.MovieDB_AutoFanartAmount)
                     {

--- a/JMMServer/Providers/TvDB/TvDBHelper.cs
+++ b/JMMServer/Providers/TvDB/TvDBHelper.cs
@@ -9,6 +9,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using JMMServer.Commands;
 using JMMServer.Entities;
 using JMMServer.Repositories;
+using JMMServer.Repositories.NHibernate;
 using NLog;
 
 namespace JMMServer.Providers.TvDB
@@ -404,13 +405,15 @@ namespace JMMServer.Providers.TvDB
 
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                foreach (TvDB_ImageFanart fanart in repFanart.GetBySeriesID(session, seriesID))
+                ISessionWrapper sessionWrapper = session.Wrap();
+
+                foreach (TvDB_ImageFanart fanart in repFanart.GetBySeriesID(sessionWrapper, seriesID))
                 {
                     if (!string.IsNullOrEmpty(fanart.FullImagePath) && File.Exists(fanart.FullImagePath))
                         numFanartDownloaded++;
                 }
 
-                foreach (TvDB_ImagePoster poster in repPosters.GetBySeriesID(session, seriesID))
+                foreach (TvDB_ImagePoster poster in repPosters.GetBySeriesID(sessionWrapper, seriesID))
                 {
                     if (!string.IsNullOrEmpty(poster.FullImagePath) && File.Exists(poster.FullImagePath))
                         numPostersDownloaded++;

--- a/JMMServer/Repositories/AniDB_AnimeRepository.cs
+++ b/JMMServer/Repositories/AniDB_AnimeRepository.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using JMMServer.Databases;
+using JMMContracts;
+using JMMServer.Collections;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -32,7 +33,7 @@ namespace JMMServer.Repositories
                     }
                 }
 
-                obj.UpdateContractDetailed(session);
+                obj.UpdateContractDetailed(session.Wrap());
                 // populate the database
 
                 using (var transaction = session.BeginTransaction())
@@ -46,26 +47,37 @@ namespace JMMServer.Repositories
         public static void InitCache()
         {
             string t = "AniDB_Anime";
-            ServerState.Instance.CurrentSetupStatus = string.Format(JMMServer.Properties.Resources.Database_Cache, t, string.Empty);
-            AniDB_AnimeRepository repo = new AniDB_AnimeRepository();
-            using (var session = JMMService.SessionFactory.OpenSession())
+            ServerState.Instance.CurrentSetupStatus = string.Format(Properties.Resources.Database_Cache, t, string.Empty);
+
+            using (var session = JMMService.SessionFactory.OpenStatelessSession())
             {
-                List<AniDB_Anime> ls =
-                    repo.GetAll(session).Where(a => a.ContractVersion < AniDB_Anime.CONTRACT_VERSION).ToList();
-                int max = ls.Count;
-                int cnt = 0;
-                foreach (AniDB_Anime a in ls)
+                const int batchSize = 50;
+                ISessionWrapper sessionWrapper = session.Wrap();
+                IList<AniDB_Anime> animeToUpdate = session.CreateCriteria<AniDB_Anime>()
+                    .Add(Restrictions.Lt(nameof(AniDB_Anime.ContractVersion), AniDB_Anime.CONTRACT_VERSION))
+                    .List<AniDB_Anime>();
+                int max = animeToUpdate.Count;
+                int count = 0;
+
+                foreach (AniDB_Anime[] animeBatch in animeToUpdate.Batch(batchSize))
                 {
-                    repo.Save(session, a);
-                    cnt++;
-                    if (cnt%10 == 0)
+                    AniDB_Anime.UpdateContractDetailedBatch(sessionWrapper, animeBatch);
+
+                    using (ITransaction trans = session.BeginTransaction())
                     {
-                        ServerState.Instance.CurrentSetupStatus = string.Format(JMMServer.Properties.Resources.Database_Cache, t,
-                            " DbRegen - " + cnt + "/" + max);
+                        foreach (AniDB_Anime anime in animeBatch)
+                        {
+                            session.Update(anime);
+                            count++;
+                        }
+
+                        trans.Commit();
                     }
+
+                    ServerState.Instance.CurrentSetupStatus = string.Format(Properties.Resources.Database_Cache, t, " DbRegen - " + count + "/" + max);
                 }
-                ServerState.Instance.CurrentSetupStatus = string.Format(JMMServer.Properties.Resources.Database_Cache, t,
-                    " DbRegen - " + max + "/" + max);
+
+                ServerState.Instance.CurrentSetupStatus = string.Format(Properties.Resources.Database_Cache, t, " DbRegen - " + max + "/" + max);
             }
         }
 
@@ -89,7 +101,7 @@ namespace JMMServer.Repositories
             }
         }
 
-        public AniDB_Anime GetByAnimeID(ISession session, int id)
+        public AniDB_Anime GetByAnimeID(ISessionWrapper session, int id)
         {
             AniDB_Anime cr = session
                 .CreateCriteria(typeof(AniDB_Anime))
@@ -188,5 +200,145 @@ namespace JMMServer.Repositories
                 return new List<AniDB_Anime>(objs);
             }
         }
+
+        public Dictionary<int, DefaultAnimeImages> GetDefaultImagesByAnime(ISessionWrapper session, int[] animeIds)
+        {
+            if (session == null)
+                throw new ArgumentNullException("session");
+            if (animeIds == null)
+                throw new ArgumentNullException("animeIds");
+
+            var defImagesByAnime = new Dictionary<int, DefaultAnimeImages>();
+
+            if (animeIds.Length == 0)
+            {
+                return defImagesByAnime;
+            }
+
+            // TODO: Determine if joining on the correct columns
+            var results = session.CreateSQLQuery($@"
+                SELECT {{defImg.*}}, {{tvWide.*}}, {{tvPoster.*}}, {{tvFanart.*}}, {{movPoster.*}}, {{movFanart.*}}, {{traktFanart.*}}, {{traktPoster.*}}
+                    FROM AniDB_Anime_DefaultImage defImg
+                        LEFT OUTER JOIN TvDB_ImageWideBanner AS tvWide
+                            ON tvWide.TvDB_ImageWideBannerID = defImg.ImageParentID AND defImg.ImageParentType = {JMMImageType.TvDB_Banner:D}
+                        LEFT OUTER JOIN TvDB_ImagePoster AS tvPoster
+                            ON tvPoster.TvDB_ImagePosterID = defImg.ImageParentID AND defImg.ImageParentType = {JMMImageType.TvDB_Cover:D}
+                        LEFT OUTER JOIN TvDB_ImageFanart AS tvFanart
+                            ON tvFanart.TvDB_ImageFanartID = defImg.ImageParentID AND defImg.ImageParentType = {JMMImageType.TvDB_FanArt:D}
+                        LEFT OUTER JOIN MovieDB_Poster AS movPoster
+                            ON movPoster.MovieDB_PosterID = defImg.ImageParentID AND defImg.ImageParentType = {JMMImageType.MovieDB_Poster:D}
+                        LEFT OUTER JOIN MovieDB_Fanart AS movFanart
+                            ON movFanart.MovieDB_FanartID = defImg.ImageParentID AND defImg.ImageParentType = {JMMImageType.MovieDB_FanArt:D}
+                        LEFT OUTER JOIN Trakt_ImageFanart AS traktFanart
+                            ON traktFanart.Trakt_ImageFanartID = defImg.ImageParentID AND defImg.ImageParentType = {JMMImageType.Trakt_Fanart:D}
+                        LEFT OUTER JOIN Trakt_ImagePoster AS traktPoster
+                            ON traktPoster.Trakt_ImagePosterID = defImg.ImageParentID AND defImg.ImageParentType = {JMMImageType.Trakt_Poster:D}
+                    WHERE defImg.AnimeID IN (:animeIds)")
+                .AddEntity("defImg", typeof(AniDB_Anime_DefaultImage))
+                .AddEntity("tvWide", typeof(TvDB_ImageWideBanner))
+                .AddEntity("tvPoster", typeof(TvDB_ImagePoster))
+                .AddEntity("tvFanart", typeof(TvDB_ImageFanart))
+                .AddEntity("movPoster", typeof(MovieDB_Poster))
+                .AddEntity("movFanart", typeof(MovieDB_Fanart))
+                .AddEntity("traktFanart", typeof(Trakt_ImageFanart))
+                .AddEntity("traktPoster", typeof(Trakt_ImagePoster))
+                .SetParameterList("animeIds", animeIds)
+                .List<object[]>();
+
+            foreach (object[] result in results)
+            {
+                var aniDbDefImage = (AniDB_Anime_DefaultImage)result[0];
+                IImageEntity parentImage = null;
+
+                switch ((JMMImageType)aniDbDefImage.ImageParentType)
+                {
+                    case JMMImageType.TvDB_Banner:
+                        parentImage = (IImageEntity)result[1];
+                        break;
+                    case JMMImageType.TvDB_Cover:
+                        parentImage = (IImageEntity)result[2];
+                        break;
+                    case JMMImageType.TvDB_FanArt:
+                        parentImage = (IImageEntity)result[3];
+                        break;
+                    case JMMImageType.MovieDB_Poster:
+                        parentImage = (IImageEntity)result[4];
+                        break;
+                    case JMMImageType.MovieDB_FanArt:
+                        parentImage = (IImageEntity)result[5];
+                        break;
+                    case JMMImageType.Trakt_Fanart:
+                        parentImage = (IImageEntity)result[6];
+                        break;
+                    case JMMImageType.Trakt_Poster:
+                        parentImage = (IImageEntity)result[7];
+                        break;
+                }
+
+                DefaultAnimeImages defImages;
+                DefaultAnimeImage defImage = new DefaultAnimeImage(aniDbDefImage, parentImage);
+
+                if (!defImagesByAnime.TryGetValue(aniDbDefImage.AnimeID, out defImages))
+                {
+                    defImages = new DefaultAnimeImages { AnimeID = aniDbDefImage.AnimeID };
+                    defImagesByAnime.Add(defImages.AnimeID, defImages);
+                }
+
+                switch (defImage.AniDBImageSizeType)
+                {
+                    case ImageSizeType.Poster:
+                        defImages.Poster = defImage;
+                        break;
+                    case ImageSizeType.WideBanner:
+                        defImages.WideBanner = defImage;
+                        break;
+                    case ImageSizeType.Fanart:
+                        defImages.Fanart = defImage;
+                        break;
+                }
+            }
+
+            return defImagesByAnime;
+        }
+    }
+
+    public class DefaultAnimeImages
+    {
+        public int AnimeID { get; set; }
+
+        public DefaultAnimeImage Poster { get; set; }
+
+        public DefaultAnimeImage Fanart { get; set; }
+
+        public DefaultAnimeImage WideBanner { get; set;  }
+    }
+
+    public class DefaultAnimeImage
+    {
+        private readonly IImageEntity _parentImage;
+
+        public DefaultAnimeImage(AniDB_Anime_DefaultImage aniDbImage, IImageEntity parentImage)
+        {
+            if (aniDbImage == null)
+                throw new ArgumentNullException(nameof(aniDbImage));
+            if (parentImage == null)
+                throw new ArgumentNullException(nameof(parentImage));
+
+            AniDBImage = aniDbImage;
+            _parentImage = parentImage;
+        }
+
+        public Contract_AniDB_Anime_DefaultImage ToContract()
+        {
+            return AniDBImage.ToContract(_parentImage);
+        }
+
+        public TImageType GetParentImage<TImageType>() where TImageType : class, IImageEntity  => _parentImage as TImageType;
+
+        public ImageSizeType AniDBImageSizeType => (ImageSizeType)AniDBImage.ImageType;
+
+        public AniDB_Anime_DefaultImage AniDBImage { get; private set; }
+
+        public JMMImageType ParentImageType => (JMMImageType)AniDBImage.ImageParentType;
     }
 }

--- a/JMMServer/Repositories/AniDB_Anime_CharacterRepository.cs
+++ b/JMMServer/Repositories/AniDB_Anime_CharacterRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -41,7 +42,7 @@ namespace JMMServer.Repositories
             }
         }
 
-        public List<AniDB_Anime_Character> GetByAnimeID(ISession session, int id)
+        public List<AniDB_Anime_Character> GetByAnimeID(ISessionWrapper session, int id)
         {
             var cats = session
                 .CreateCriteria(typeof(AniDB_Anime_Character))

--- a/JMMServer/Repositories/AniDB_Anime_DefaultImageRepository.cs
+++ b/JMMServer/Repositories/AniDB_Anime_DefaultImageRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -49,11 +50,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAnimeIDAndImagezSizeType(session, animeid, imageType);
+                return GetByAnimeIDAndImagezSizeType(session.Wrap(), animeid, imageType);
             }
         }
 
-        public AniDB_Anime_DefaultImage GetByAnimeIDAndImagezSizeType(ISession session, int animeid, int imageType)
+        public AniDB_Anime_DefaultImage GetByAnimeIDAndImagezSizeType(ISessionWrapper session, int animeid, int imageType)
         {
             AniDB_Anime_DefaultImage cr = session
                 .CreateCriteria(typeof(AniDB_Anime_DefaultImage))

--- a/JMMServer/Repositories/AniDB_Anime_RelationRepository.cs
+++ b/JMMServer/Repositories/AniDB_Anime_RelationRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -50,11 +51,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAnimeID(session, id);
+                return GetByAnimeID(session.Wrap(), id);
             }
         }
 
-        public List<AniDB_Anime_Relation> GetByAnimeID(ISession session, int id)
+        public List<AniDB_Anime_Relation> GetByAnimeID(ISessionWrapper session, int id)
         {
             var cats = session
                 .CreateCriteria(typeof(AniDB_Anime_Relation))

--- a/JMMServer/Repositories/AniDB_Anime_TagRepository.cs
+++ b/JMMServer/Repositories/AniDB_Anime_TagRepository.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using JMMServer.Collections;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -54,7 +58,7 @@ namespace JMMServer.Repositories
             }
         }
 
-        public AniDB_Anime_Tag GetByAnimeIDAndTagID(ISession session, int animeid, int tagid)
+        public AniDB_Anime_Tag GetByAnimeIDAndTagID(ISessionWrapper session, int animeid, int tagid)
         {
             AniDB_Anime_Tag cr = session
                 .CreateCriteria(typeof(AniDB_Anime_Tag))
@@ -77,7 +81,7 @@ namespace JMMServer.Repositories
             }
         }
 
-        public List<AniDB_Anime_Tag> GetByAnimeID(ISession session, int id)
+        public List<AniDB_Anime_Tag> GetByAnimeID(ISessionWrapper session, int id)
         {
             var tags = session
                 .CreateCriteria(typeof(AniDB_Anime_Tag))
@@ -85,6 +89,26 @@ namespace JMMServer.Repositories
                 .List<AniDB_Anime_Tag>();
 
             return new List<AniDB_Anime_Tag>(tags);
+        }
+
+        public ILookup<int, AniDB_Anime_Tag> GetByAnimeIDs(ISessionWrapper session, ICollection<int> ids)
+        {
+            if (session == null)
+                throw new ArgumentNullException(nameof(session));
+            if (ids == null)
+                throw new ArgumentNullException(nameof(ids));
+
+            if (ids.Count == 0)
+            {
+                return EmptyLookup<int, AniDB_Anime_Tag>.Instance;
+            }
+
+            var tags = session.CreateCriteria<AniDB_Anime_Tag>()
+                .Add(Restrictions.InG(nameof(AniDB_Anime_Tag.AnimeID), ids))
+                .List<AniDB_Anime_Tag>()
+                .ToLookup(t => t.AnimeID);
+
+            return tags;
         }
 
         /// <summary>

--- a/JMMServer/Repositories/AniDB_Anime_TitleRepository.cs
+++ b/JMMServer/Repositories/AniDB_Anime_TitleRepository.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using JMMServer.Collections;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -54,7 +58,7 @@ namespace JMMServer.Repositories
             }
         }
 
-        public List<AniDB_Anime_Title> GetByAnimeID(ISession session, int id)
+        public List<AniDB_Anime_Title> GetByAnimeID(ISessionWrapper session, int id)
         {
             var titles = session
                 .CreateCriteria(typeof(AniDB_Anime_Title))
@@ -62,6 +66,26 @@ namespace JMMServer.Repositories
                 .List<AniDB_Anime_Title>();
 
             return new List<AniDB_Anime_Title>(titles);
+        }
+
+        public ILookup<int, AniDB_Anime_Title> GetByAnimeIDs(ISessionWrapper session, ICollection<int> ids)
+        {
+            if (session == null)
+                throw new ArgumentNullException("session");
+            if (ids == null)
+                throw new ArgumentNullException("ids");
+
+            if (ids.Count == 0)
+            {
+                return EmptyLookup<int, AniDB_Anime_Title>.Instance;
+            }
+
+            var titles = session.CreateCriteria<AniDB_Anime_Title>()
+                .Add(Restrictions.InG(nameof(AniDB_Anime_Title.AnimeID), ids))
+                .List<AniDB_Anime_Title>()
+                .ToLookup(t => t.AnimeID);
+
+            return titles;
         }
 
         public List<AniDB_Anime_Title> GetByAnimeIDLanguageTypeValue(int animeID, string language, string titleType,

--- a/JMMServer/Repositories/AniDB_CharacterRepository.cs
+++ b/JMMServer/Repositories/AniDB_CharacterRepository.cs
@@ -1,5 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using JMMContracts;
+using JMMServer.Collections;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -44,17 +49,59 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByCharID(session, id);
+                return GetByCharID(session.Wrap(), id);
             }
         }
 
-        public AniDB_Character GetByCharID(ISession session, int id)
+        public AniDB_Character GetByCharID(ISessionWrapper session, int id)
         {
             AniDB_Character cr = session
                 .CreateCriteria(typeof(AniDB_Character))
                 .Add(Restrictions.Eq("CharID", id))
                 .UniqueResult<AniDB_Character>();
             return cr;
+        }
+
+        public ILookup<int, AnimeCharacterAndSeiyuu> GetCharacterAndSeiyuuByAnime(ISessionWrapper session, int[] animeIds)
+        {
+            if (session == null)
+                throw new ArgumentNullException(nameof(session));
+            if (animeIds == null)
+                throw new ArgumentNullException(nameof(animeIds));
+
+            if (animeIds.Length == 0)
+            {
+                return EmptyLookup<int, AnimeCharacterAndSeiyuu>.Instance;
+            }
+
+            // The below query makes sure that only one seiyuu is returned for each anime/character combiniation
+            var animeChars = session.CreateSQLQuery(@"
+                SELECT animeChr.AnimeID, {chr.*}, {seiyuu.*}, animeChr.CharType
+                    FROM AniDB_Anime_Character AS animeChr
+                        INNER JOIN AniDB_Character AS chr
+                            ON chr.CharID = animeChr.CharID
+                        LEFT OUTER JOIN (
+                            SELECT ac.AnimeID, ac.CharID, MIN(cs.SeiyuuID) AS SeiyuuID
+                                FROM AniDB_Anime_Character ac
+                                    INNER JOIN AniDB_Character_Seiyuu cs
+                                        ON cs.CharID = ac.CharID
+                                GROUP BY ac.AnimeID, ac.CharID
+                            ) AS chrSeiyuu
+                            ON chrSeiyuu.CharID = chr.CharID
+                                AND chrSeiyuu.AnimeID = animeChr.AnimeID
+                        LEFT OUTER JOIN AniDB_Seiyuu AS seiyuu
+                            ON seiyuu.SeiyuuID = chrSeiyuu.SeiyuuID
+                    WHERE animeChr.AnimeID IN (:animeIds)")
+                .AddScalar("AnimeID", NHibernateUtil.Int32)
+                .AddEntity("chr", typeof(AniDB_Character))
+                .AddEntity("seiyuu", typeof(AniDB_Seiyuu))
+                .AddScalar("CharType", NHibernateUtil.String)
+                .SetParameterList("animeIds", animeIds)
+                .List<object[]>()
+                .Select(r => new AnimeCharacterAndSeiyuu((int)r[0], (AniDB_Character)r[1], (AniDB_Seiyuu)r[2], (string)r[3]))
+                .ToLookup(ac => ac.AnimeID);
+
+            return animeChars;
         }
 
         public void Delete(int id)
@@ -73,5 +120,32 @@ namespace JMMServer.Repositories
                 }
             }
         }
+    }
+
+    public class AnimeCharacterAndSeiyuu
+    {
+        public AnimeCharacterAndSeiyuu(int animeID, AniDB_Character character, AniDB_Seiyuu seiyuu = null, string characterType = null)
+        {
+            if (character == null)
+                throw new ArgumentNullException(nameof(character));
+
+            AnimeID = animeID;
+            Character = character;
+            Seiyuu = seiyuu;
+            CharacterType = characterType ?? String.Empty;
+        }
+
+        public Contract_AniDB_Character ToContract()
+        {
+            return Character.ToContract(CharacterType, Seiyuu);
+        }
+
+        public int AnimeID { get; private set; }
+
+        public AniDB_Character Character { get; private set; }
+
+        public AniDB_Seiyuu Seiyuu { get; private set; }
+
+        public string CharacterType { get; private set; }
     }
 }

--- a/JMMServer/Repositories/AniDB_EpisodeRepository.cs
+++ b/JMMServer/Repositories/AniDB_EpisodeRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using AniDBAPI;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -45,11 +46,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAnimeID(session, id);
+                return GetByAnimeID(session.Wrap(), id);
             }
         }
 
-        public List<AniDB_Episode> GetByAnimeID(ISession session, int id)
+        public List<AniDB_Episode> GetByAnimeID(ISessionWrapper session, int id)
         {
             var eps = session
                 .CreateCriteria(typeof(AniDB_Episode))

--- a/JMMServer/Repositories/AniDB_FileRepository.cs
+++ b/JMMServer/Repositories/AniDB_FileRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 using NLog;
@@ -41,11 +42,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByHash(session, hash);
+                return GetByHash(session.Wrap(), hash);
             }
         }
 
-        public AniDB_File GetByHash(ISession session, string hash)
+        public AniDB_File GetByHash(ISessionWrapper session, string hash)
         {
             AniDB_File cr = session
                 .CreateCriteria(typeof(AniDB_File))

--- a/JMMServer/Repositories/AniDB_RecommendationRepository.cs
+++ b/JMMServer/Repositories/AniDB_RecommendationRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 using NLog;
@@ -35,11 +36,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAnimeID(session, id);
+                return GetByAnimeID(session.Wrap(), id);
             }
         }
 
-        public List<AniDB_Recommendation> GetByAnimeID(ISession session, int id)
+        public List<AniDB_Recommendation> GetByAnimeID(ISessionWrapper session, int id)
         {
             var votes = session
                 .CreateCriteria(typeof(AniDB_Recommendation))

--- a/JMMServer/Repositories/AniDB_VoteRepository.cs
+++ b/JMMServer/Repositories/AniDB_VoteRepository.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -111,6 +114,24 @@ namespace JMMServer.Repositories
             }
 
             return null;
+        }
+
+        public Dictionary<int, AniDB_Vote> GetByAnimeIDs(ISessionWrapper session, ICollection<int> animeIDs)
+        {
+            if (session == null)
+                throw new ArgumentNullException(nameof(session));
+            if (animeIDs == null)
+                throw new ArgumentNullException(nameof(animeIDs));
+
+            var votesByAnime = session
+                .CreateCriteria<AniDB_Vote>()
+                .Add(Restrictions.InG(nameof(AniDB_Vote.EntityID), animeIDs))
+                .Add(Restrictions.In(nameof(AniDB_Vote.VoteType), new[] { (int)AniDBVoteType.Anime, (int)AniDBVoteType.AnimeTemp }))
+                .List<AniDB_Vote>()
+                .GroupBy(v => v.EntityID)
+                .ToDictionary(g => g.Key, g => g.FirstOrDefault());
+
+            return votesByAnime;
         }
 
         public void Delete(int id)

--- a/JMMServer/Repositories/AnimeEpisodeRepository.cs
+++ b/JMMServer/Repositories/AnimeEpisodeRepository.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using JMMServer.Databases;
 using JMMServer.Entities;
 using JMMServer.PlexAndKodi;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NutzCode.InMemoryIndex;
 
@@ -112,7 +113,7 @@ namespace JMMServer.Repositories
             return Series.GetMultiple(seriesid);
         }
 
-        public List<AnimeEpisode> GetBySeriesID(ISession session, int seriesid)
+        public List<AnimeEpisode> GetBySeriesID(ISessionWrapper session, int seriesid)
         {
             return GetBySeriesID(seriesid);
         }

--- a/JMMServer/Repositories/AnimeEpisode_UserRepository.cs
+++ b/JMMServer/Repositories/AnimeEpisode_UserRepository.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using JMMContracts;
 using JMMServer.Databases;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NutzCode.InMemoryIndex;
 
@@ -158,7 +159,7 @@ namespace JMMServer.Repositories
             return UsersSeries.GetMultiple(userid, seriesid);
         }
 
-        public List<AnimeEpisode_User> GetByUserIDAndSeriesID(ISession session, int userid, int seriesid)
+        public List<AnimeEpisode_User> GetByUserIDAndSeriesID(ISessionWrapper session, int userid, int seriesid)
         {
             return GetByUserIDAndSeriesID(userid, seriesid);
         }

--- a/JMMServer/Repositories/AnimeGroupRepository.cs
+++ b/JMMServer/Repositories/AnimeGroupRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JMMServer.Databases;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 using NutzCode.InMemoryIndex;
@@ -60,6 +61,7 @@ namespace JMMServer.Repositories
 
             using (var session = JMMService.SessionFactory.OpenSession())
             {
+                ISessionWrapper sessionWrapper = session.Wrap();
                 HashSet<GroupFilterConditionType> types;
                 lock (grp)
                 {
@@ -73,7 +75,7 @@ namespace JMMServer.Repositories
                             transaction.Commit();
                         }
                     }
-                    types = grp.UpdateContract(session, updategrpcontractstats);
+                    types = grp.UpdateContract(sessionWrapper, updategrpcontractstats);
                     //Types will contains the affected GroupFilterConditionTypes
                     using (var transaction = session.BeginTransaction())
                     {
@@ -91,7 +93,7 @@ namespace JMMServer.Repositories
                 }
                 if (grp.AnimeGroupParentID.HasValue && recursive)
                 {
-                    AnimeGroup pgroup = GetByID(session, grp.AnimeGroupParentID.Value);
+                    AnimeGroup pgroup = GetByID(sessionWrapper, grp.AnimeGroupParentID.Value);
 					// This will avoid the recursive error that would be possible, it won't update it, but that would be
 					// the least of the issues
 					if(pgroup != null && pgroup.AnimeGroupParentID == grp.AnimeGroupID)
@@ -105,7 +107,7 @@ namespace JMMServer.Repositories
             return Cache.Get(id);
         }
 
-        public AnimeGroup GetByID(ISession session, int id)
+        public AnimeGroup GetByID(ISessionWrapper session, int id)
         {
             return GetByID(id);
         }
@@ -115,7 +117,7 @@ namespace JMMServer.Repositories
             return Parents.GetMultiple(parentid);
         }
 
-        public List<AnimeGroup> GetByParentID(ISession session, int parentid)
+        public List<AnimeGroup> GetByParentID(ISessionWrapper session, int parentid)
         {
             return GetByParentID(parentid);
         }

--- a/JMMServer/Repositories/AnimeSeriesRepository.cs
+++ b/JMMServer/Repositories/AnimeSeriesRepository.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using JMMServer.Databases;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 using NutzCode.InMemoryIndex;
@@ -158,7 +159,7 @@ namespace JMMServer.Repositories
             return Cache.Get(id);
         }
 
-        public AnimeSeries GetByID(ISession session, int id)
+        public AnimeSeries GetByID(ISessionWrapper session, int id)
         {
             return GetByID(id);
         }
@@ -168,7 +169,7 @@ namespace JMMServer.Repositories
             return AniDBIds.GetOne(id);
         }
 
-        public AnimeSeries GetByAnimeID(ISession session, int id)
+        public AnimeSeries GetByAnimeID(ISessionWrapper session, int id)
         {
             return GetByAnimeID(id);
         }

--- a/JMMServer/Repositories/AnimeSeries_UserRepository.cs
+++ b/JMMServer/Repositories/AnimeSeries_UserRepository.cs
@@ -4,6 +4,7 @@ using JMMContracts;
 using JMMServer.Databases;
 using JMMServer.Entities;
 using JMMServer.PlexAndKodi;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 using NutzCode.InMemoryIndex;
@@ -106,7 +107,7 @@ namespace JMMServer.Repositories
                 Contract_AnimeSeries con = ser?.GetUserContract(ugrp.JMMUserID);
                 if (con == null)
                     return;
-                ugrp.PlexContract = Helper.GenerateFromSeries(con, ser, ser.GetAnime(session), ugrp.JMMUserID);
+                ugrp.PlexContract = Helper.GenerateFromSeries(con, ser, ser.GetAnime(session.Wrap()), ugrp.JMMUserID);
             }
         }
 

--- a/JMMServer/Repositories/CrossRef_AniDB_OtherRepository.cs
+++ b/JMMServer/Repositories/CrossRef_AniDB_OtherRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -32,11 +33,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAnimeIDAndType(session, animeID, xrefType);
+                return GetByAnimeIDAndType(session.Wrap(), animeID, xrefType);
             }
         }
 
-        public CrossRef_AniDB_Other GetByAnimeIDAndType(ISession session, int animeID, CrossRefType xrefType)
+        public CrossRef_AniDB_Other GetByAnimeIDAndType(ISessionWrapper session, int animeID, CrossRefType xrefType)
         {
             CrossRef_AniDB_Other cr = session
                 .CreateCriteria(typeof(CrossRef_AniDB_Other))

--- a/JMMServer/Repositories/CrossRef_AniDB_TvDBV2Repository.cs
+++ b/JMMServer/Repositories/CrossRef_AniDB_TvDBV2Repository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -32,11 +33,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAnimeID(session, id);
+                return GetByAnimeID(session.Wrap(), id);
             }
         }
 
-        public List<CrossRef_AniDB_TvDBV2> GetByAnimeID(ISession session, int id)
+        public List<CrossRef_AniDB_TvDBV2> GetByAnimeID(ISessionWrapper session, int id)
         {
             var xrefs = session
                 .CreateCriteria(typeof(CrossRef_AniDB_TvDBV2))

--- a/JMMServer/Repositories/CrossRef_File_EpisodeRepository.cs
+++ b/JMMServer/Repositories/CrossRef_File_EpisodeRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 using NLog;
@@ -51,11 +52,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAnimeID(session, animeID);
+                return GetByAnimeID(session.Wrap(), animeID);
             }
         }
 
-        public List<CrossRef_File_Episode> GetByAnimeID(ISession session, int animeID)
+        public List<CrossRef_File_Episode> GetByAnimeID(ISessionWrapper session, int animeID)
         {
             var xrefs = session
                 .CreateCriteria(typeof(CrossRef_File_Episode))

--- a/JMMServer/Repositories/JMMUserRepository.cs
+++ b/JMMServer/Repositories/JMMUserRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using JMMContracts;
 using JMMServer.Databases;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NLog;
 using NutzCode.InMemoryIndex;
@@ -124,7 +125,7 @@ namespace JMMServer.Repositories
             return Cache.Get(id);
         }
 
-        public JMMUser GetByID(ISession session, int id)
+        public JMMUser GetByID(ISessionWrapper session, int id)
         {
             return Cache.Get(id);
         }
@@ -134,7 +135,7 @@ namespace JMMServer.Repositories
             return Cache.Values.ToList();
         }
 
-        public List<JMMUser> GetAll(ISession session)
+        public List<JMMUser> GetAll(ISessionWrapper session)
         {
             return Cache.Values.ToList();
         }

--- a/JMMServer/Repositories/MovieDB_FanartRepository.cs
+++ b/JMMServer/Repositories/MovieDB_FanartRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -29,11 +30,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByID(session, id);
+                return GetByID(session.Wrap(), id);
             }
         }
 
-        public MovieDB_Fanart GetByID(ISession session, int id)
+        public MovieDB_Fanart GetByID(ISessionWrapper session, int id)
         {
             return session.Get<MovieDB_Fanart>(id);
         }
@@ -59,11 +60,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByMovieID(session, id);
+                return GetByMovieID(session.Wrap(), id);
             }
         }
 
-        public List<MovieDB_Fanart> GetByMovieID(ISession session, int id)
+        public List<MovieDB_Fanart> GetByMovieID(ISessionWrapper session, int id)
         {
             var objs = session
                 .CreateCriteria(typeof(MovieDB_Fanart))

--- a/JMMServer/Repositories/MovieDB_MovieRepository.cs
+++ b/JMMServer/Repositories/MovieDB_MovieRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -37,11 +38,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByOnlineID(session, id);
+                return GetByOnlineID(session.Wrap(), id);
             }
         }
 
-        public MovieDB_Movie GetByOnlineID(ISession session, int id)
+        public MovieDB_Movie GetByOnlineID(ISessionWrapper session, int id)
         {
             MovieDB_Movie cr = session
                 .CreateCriteria(typeof(MovieDB_Movie))

--- a/JMMServer/Repositories/MovieDB_PosterRepository.cs
+++ b/JMMServer/Repositories/MovieDB_PosterRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -29,11 +30,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByID(session, id);
+                return GetByID(session.Wrap(), id);
             }
         }
 
-        public MovieDB_Poster GetByID(ISession session, int id)
+        public MovieDB_Poster GetByID(ISessionWrapper session, int id)
         {
             return session.Get<MovieDB_Poster>(id);
         }
@@ -59,11 +60,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByMovieID(session, id);
+                return GetByMovieID(session.Wrap(), id);
             }
         }
 
-        public List<MovieDB_Poster> GetByMovieID(ISession session, int id)
+        public List<MovieDB_Poster> GetByMovieID(ISessionWrapper session, int id)
         {
             var objs = session
                 .CreateCriteria(typeof(MovieDB_Poster))

--- a/JMMServer/Repositories/NHibernate/ISessionWrapper.cs
+++ b/JMMServer/Repositories/NHibernate/ISessionWrapper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Data;
+using NHibernate;
+
+namespace JMMServer.Repositories.NHibernate
+{
+    public interface ISessionWrapper
+    {
+        ICriteria CreateCriteria<T>() where T : class;
+
+        ICriteria CreateCriteria(Type type);
+
+        IQuery CreateQuery(string query);
+
+        ISQLQuery CreateSQLQuery(string query);
+
+        TObj Get<TObj>(object id);
+
+        IDbConnection Connection { get; } 
+    }
+}

--- a/JMMServer/Repositories/NHibernate/SessionExtensions.cs
+++ b/JMMServer/Repositories/NHibernate/SessionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using NHibernate;
+
+namespace JMMServer.Repositories.NHibernate
+{
+    internal static class SessionExtensions
+    {
+        public static ISessionWrapper Wrap(this ISession session)
+        {
+            return new SessionWrapper(session);
+        }
+    }
+}

--- a/JMMServer/Repositories/NHibernate/SessionWrapper.cs
+++ b/JMMServer/Repositories/NHibernate/SessionWrapper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Data;
+using NHibernate;
+
+namespace JMMServer.Repositories.NHibernate
+{
+    internal class SessionWrapper : ISessionWrapper
+    {
+        private readonly ISession _session;
+
+        public SessionWrapper(ISession session)
+        {
+            if (session == null)
+                throw new ArgumentNullException("session");
+
+            _session = session;
+        }
+
+        public ICriteria CreateCriteria(Type type)
+        {
+            return _session.CreateCriteria(type);
+        }
+
+        public ICriteria CreateCriteria<T>() where T : class
+        {
+            return _session.CreateCriteria<T>();
+        }
+
+        public IQuery CreateQuery(string query)
+        {
+            return _session.CreateQuery(query);
+        }
+
+        public ISQLQuery CreateSQLQuery(string query)
+        {
+            return _session.CreateSQLQuery(query);
+        }
+
+        public TObj Get<TObj>(object id)
+        {
+            return _session.Get<TObj>(id);
+        }
+
+        public IDbConnection Connection
+        {
+            get { return _session.Connection; }
+        }
+    }
+}

--- a/JMMServer/Repositories/NHibernate/StatelessSessionExtensions.cs
+++ b/JMMServer/Repositories/NHibernate/StatelessSessionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using NHibernate;
+
+namespace JMMServer.Repositories.NHibernate
+{
+    internal static class StatelessSessionExtensions
+    {
+        public static ISessionWrapper Wrap(this IStatelessSession session)
+        {
+            return new StatelessSessionWrapper(session);
+        }
+    }
+}

--- a/JMMServer/Repositories/NHibernate/StatelessSessionWrapper.cs
+++ b/JMMServer/Repositories/NHibernate/StatelessSessionWrapper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Data;
+using NHibernate;
+
+namespace JMMServer.Repositories.NHibernate
+{
+    internal class StatelessSessionWrapper : ISessionWrapper
+    {
+        private readonly IStatelessSession _session;
+
+        public StatelessSessionWrapper(IStatelessSession session)
+        {
+            if (session == null)
+                throw new ArgumentNullException("session");
+
+            _session = session;
+        }
+
+        public ICriteria CreateCriteria(Type type)
+        {
+            return _session.CreateCriteria(type);
+        }
+
+        public ICriteria CreateCriteria<T>() where T : class
+        {
+            return _session.CreateCriteria<T>();
+        }
+
+        public IQuery CreateQuery(string query)
+        {
+            return _session.CreateQuery(query);
+        }
+
+        public ISQLQuery CreateSQLQuery(string query)
+        {
+            return _session.CreateSQLQuery(query);
+        }
+
+        public TObj Get<TObj>(object id)
+        {
+            return _session.Get<TObj>(id);
+        }
+
+        public IDbConnection Connection
+        {
+            get { return _session.Connection; }
+        }
+    }
+}

--- a/JMMServer/Repositories/Trakt_ImageFanartRepository.cs
+++ b/JMMServer/Repositories/Trakt_ImageFanartRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -24,11 +25,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByID(session, id);
+                return GetByID(session.Wrap(), id);
             }
         }
 
-        public Trakt_ImageFanart GetByID(ISession session, int id)
+        public Trakt_ImageFanart GetByID(ISessionWrapper session, int id)
         {
             return session.Get<Trakt_ImageFanart>(id);
         }

--- a/JMMServer/Repositories/Trakt_ImagePosterRepository.cs
+++ b/JMMServer/Repositories/Trakt_ImagePosterRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -24,11 +25,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByID(session, id);
+                return GetByID(session.Wrap(), id);
             }
         }
 
-        public Trakt_ImagePoster GetByID(ISession session, int id)
+        public Trakt_ImagePoster GetByID(ISessionWrapper session, int id)
         {
             return session.Get<Trakt_ImagePoster>(id);
         }

--- a/JMMServer/Repositories/TvDB_EpisodeRepository.cs
+++ b/JMMServer/Repositories/TvDB_EpisodeRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -44,11 +45,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetBySeriesID(session, seriesID);
+                return GetBySeriesID(session.Wrap(), seriesID);
             }
         }
 
-        public List<TvDB_Episode> GetBySeriesID(ISession session, int seriesID)
+        public List<TvDB_Episode> GetBySeriesID(ISessionWrapper session, int seriesID)
         {
             var objs = session
                 .CreateCriteria(typeof(TvDB_Episode))

--- a/JMMServer/Repositories/TvDB_ImageFanartRepository.cs
+++ b/JMMServer/Repositories/TvDB_ImageFanartRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -24,11 +25,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByID(session, id);
+                return GetByID(session.Wrap(), id);
             }
         }
 
-        public TvDB_ImageFanart GetByID(ISession session, int id)
+        public TvDB_ImageFanart GetByID(ISessionWrapper session, int id)
         {
             return session.Get<TvDB_ImageFanart>(id);
         }
@@ -49,11 +50,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetBySeriesID(session, seriesID);
+                return GetBySeriesID(session.Wrap(), seriesID);
             }
         }
 
-        public List<TvDB_ImageFanart> GetBySeriesID(ISession session, int seriesID)
+        public List<TvDB_ImageFanart> GetBySeriesID(ISessionWrapper session, int seriesID)
         {
             var objs = session
                 .CreateCriteria(typeof(TvDB_ImageFanart))

--- a/JMMServer/Repositories/TvDB_ImagePosterRepository.cs
+++ b/JMMServer/Repositories/TvDB_ImagePosterRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -24,11 +25,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByID(session, id);
+                return GetByID(session.Wrap(), id);
             }
         }
 
-        public TvDB_ImagePoster GetByID(ISession session, int id)
+        public TvDB_ImagePoster GetByID(ISessionWrapper session, int id)
         {
             return session.Get<TvDB_ImagePoster>(id);
         }
@@ -61,11 +62,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetBySeriesID(session, seriesID);
+                return GetBySeriesID(session.Wrap(), seriesID);
             }
         }
 
-        public List<TvDB_ImagePoster> GetBySeriesID(ISession session, int seriesID)
+        public List<TvDB_ImagePoster> GetBySeriesID(ISessionWrapper session, int seriesID)
         {
             var objs = session
                 .CreateCriteria(typeof(TvDB_ImagePoster))

--- a/JMMServer/Repositories/TvDB_ImageWideBannerRepository.cs
+++ b/JMMServer/Repositories/TvDB_ImageWideBannerRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -24,11 +25,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByID(session, id);
+                return GetByID(session.Wrap(), id);
             }
         }
 
-        public TvDB_ImageWideBanner GetByID(ISession session, int id)
+        public TvDB_ImageWideBanner GetByID(ISessionWrapper session, int id)
         {
             return session.Get<TvDB_ImageWideBanner>(id);
         }

--- a/JMMServer/Repositories/TvDB_SeriesRepository.cs
+++ b/JMMServer/Repositories/TvDB_SeriesRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NHibernate.Criterion;
 
@@ -32,11 +33,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByTvDBID(session, id);
+                return GetByTvDBID(session.Wrap(), id);
             }
         }
 
-        public TvDB_Series GetByTvDBID(ISession session, int id)
+        public TvDB_Series GetByTvDBID(ISessionWrapper session, int id)
         {
             TvDB_Series cr = session
                 .CreateCriteria(typeof(TvDB_Series))

--- a/JMMServer/Repositories/VideoLocalRepository.cs
+++ b/JMMServer/Repositories/VideoLocalRepository.cs
@@ -8,6 +8,7 @@ using JMMServer.PlexAndKodi;
 using NHibernate;
 using NutzCode.InMemoryIndex;
 using System.Globalization;
+using JMMServer.Repositories.NHibernate;
 
 namespace JMMServer.Repositories
 {
@@ -276,11 +277,11 @@ namespace JMMServer.Repositories
         {
             using (var session = JMMService.SessionFactory.OpenSession())
             {
-                return GetByAniDBAnimeID(session, animeID);
+                return GetByAniDBAnimeID(session.Wrap(), animeID);
             }
         }
 
-        public List<VideoLocal> GetByAniDBAnimeID(ISession session, int animeID)
+        public List<VideoLocal> GetByAniDBAnimeID(ISessionWrapper session, int animeID)
         {
             return
                 session.CreateQuery(


### PR DESCRIPTION
After recently updating JMM Server, I encountered the cache initialization process which took several hours to complete on my media PC. So, I thought I'd see if I could improve the performance a bit.
Below is a quick summary of what I've done:

- AniDB_AnimeRepository.InitCache now uses a stateless session. Using the standard ISession has a large amount of overhead due to change tracking, etc. (the profiler I used indicated that approximately 80% of the time was spent in NHibernate's Commit method).
- The above change required the introduction of an ISessionWrapper to provide the common functionality from both ISession and IStatelessSession for performing SELECT queries in various parts of the system.
- AniDB_Anime processing was switch over to work in batches instead of one by one to reduce the number of round-trips to the database.

Below are the results of the change (Tested on an i7 2600k, 16GB RAM, SSD; with 3661 AniDB_Anime records in DB):

Database | Before | After
--- | --- | ---
**SQL Server (2014)** | 1h 02m 35s | 25s
**SQLite** | 2h 11m 30s | 27s
**MySQL (5.17.5)** | 1h 16m 12s | 2m 45s

Note that this PR only improves the cache initialization of the AniDB_Anime stage. I haven't attempted to tackle some of the other slow stages yet due to the amount of work involved. If I do make an attempt, I'll do it in a separate PR (assuming this one turns out ok).

Also, one bit that hasn't been fully tested is handling the default images in bulk. The database I'm working doesn't have any records for images (I think I must have turned that feature off), so it would be greatly appreciated if someone could give it a quick test (if not, I'll have to find some time to setup some test cases).