### PR TITLE
Follow up to #402: Removed redundant code and fixed incorrect ImageType

### DIFF
--- a/JMMServer/Entities/AniDB_Anime.cs
+++ b/JMMServer/Entities/AniDB_Anime.cs
@@ -2003,48 +2003,6 @@ namespace JMMServer.Entities
             contract.DefaultImagePoster = defPoster?.ToContract(session);
             contract.DefaultImageWideBanner = defBanner?.ToContract(session);
 
-	        // generate Fanarts and Banners
-	        if (this.AnimeTypeEnum == enAnimeType.Movie)
-	        {
-		        List<MovieDB_Fanart> fanarts = GetMovieDBFanarts(session);
-		        if (fanarts.Count > 0)
-		        {
-			        contract.Fanarts = new List<Contract_AniDB_Anime_DefaultImage>();
-			        fanarts.ForEach(a => contract.Fanarts.Add(new Contract_AniDB_Anime_DefaultImage()
-			        {
-				        ImageType = (int) JMMImageType.MovieDB_FanArt,
-				        MovieFanart = a.ToContract(),
-				        AniDB_Anime_DefaultImageID = a.MovieDB_FanartID
-			        }));
-		        }
-		        // MovieDB doesn't have banners
-	        }
-	        else
-	        {
-		        List<TvDB_ImageFanart> fanarts = GetTvDBImageFanarts(session);
-		        if (fanarts.Count > 0)
-		        {
-			        contract.Fanarts = new List<Contract_AniDB_Anime_DefaultImage>();
-			        fanarts.ForEach(a => contract.Fanarts.Add(new Contract_AniDB_Anime_DefaultImage()
-			        {
-				        ImageType = (int) JMMImageType.TvDB_FanArt,
-				        TVFanart = a.ToContract(),
-				        AniDB_Anime_DefaultImageID = a.TvDB_ImageFanartID
-			        }));
-		        }
-		        List<TvDB_ImageWideBanner> banners = GetTvDBImageWideBanners(session);
-		        if (banners.Count > 0)
-		        {
-			        contract.Banners = new List<Contract_AniDB_Anime_DefaultImage>();
-			        banners.ForEach(a => contract.Banners.Add(new Contract_AniDB_Anime_DefaultImage()
-			        {
-				        ImageType = (int) JMMImageType.TvDB_Banner,
-				        TVWideBanner = a.ToContract(),
-				        AniDB_Anime_DefaultImageID = a.TvDB_ImageWideBannerID
-			        }));
-		        }
-	        }
-
 	        return contract;
         }
 
@@ -2126,7 +2084,7 @@ namespace JMMServer.Entities
                     .ToList();
                 contract.Banners = tvDbBanners?.Select(a => new Contract_AniDB_Anime_DefaultImage
                     {
-                        ImageType = (int)JMMImageType.TvDB_FanArt,
+                        ImageType = (int)JMMImageType.TvDB_Banner,
                         TVWideBanner = a.ToContract(),
                         AniDB_Anime_DefaultImageID = a.TvDB_ImageWideBannerID
                     })


### PR DESCRIPTION
- Removed code from first AniDB_Anime.GenerateContract which repeats
  work that is done earlier in the method (ie. the image info is retrieved
  on line 1987-1994, and they're converted to contracts in the GenerateContract
  call on line 1997). I think this must have been left in before #402 merge?
- Fixed the contract generation for TvDB Banners in second
  AniDB_Anime.GenerateContract method. It was using JMMImageType.TvDB_FanArt,
  and should have been JMMImageType.TvDB_Banner.

Sorry about that second point, I think it was a copy/paste error which I didn't notice until well after #402 merge (I really need to start adopting the "just say no to clone and code" mantra).