### PR TITLE
Fixed kodi/plex contracts for RecreateAllGroups

### DIFF
--- a/JMMServer/PlexAndKodi/CommonImplementation.cs
+++ b/JMMServer/PlexAndKodi/CommonImplementation.cs
@@ -1130,7 +1130,8 @@ namespace JMMServer.PlexAndKodi
                     Dictionary<Contract_AnimeGroup, Video> order = new Dictionary<Contract_AnimeGroup, Video>();
                     if (gf.GroupsIds.ContainsKey(userid))
                     {
-                        foreach (AnimeGroup grp in gf.GroupsIds[userid].Select(a => RepoFactory.AnimeGroup.GetByID(a)).Where(a => a != null))
+                        // NOTE: The ToList() in the below foreach is required to prevent enumerable was modified exception
+                        foreach (AnimeGroup grp in gf.GroupsIds[userid].ToList().Select(a => RepoFactory.AnimeGroup.GetByID(a)).Where(a => a != null))
                         {
                             Video v = grp.GetPlexContract(userid)?.Clone<Directory>();
                             if (v != null)


### PR DESCRIPTION
Follow up to #472.

Fixed incorrect kodi/plex contract caused by stale/empty caches during RecreateAllGroups process. Basically when creating the kodi/plex contracts, the contract creation code couldn't find the Groups/Group_Users because the cache wasn't up to date.

The only issue I'm seeing now is the Art attribute isn't populated in the XML. However, I also checked the contracts on a database that I had run the original RecreateAllGroups code on (i.e. before my rewrite) and it was missing it as well. So, the issue seems to have possibly existed before my rewrite? thoughts/confirmation?
