### PR TITLE
Kodi image & AnimeGroup change tracking fixes

### DIFF
--- a/JMMServer/API/APIv2_core_Module.cs
+++ b/JMMServer/API/APIv2_core_Module.cs
@@ -16,6 +16,8 @@ using Newtonsoft.Json;
 using System.IO;
 using JMMServer.Repositories.Direct;
 using JMMServer.Utilities;
+using JMMServer.Tasks;
+using Nancy.Responses;
 
 namespace JMMServer.API
 {
@@ -181,6 +183,11 @@ namespace JMMServer.API
             Post["/log/rotate"] = x => { return SetRotateLogs(); };
             Get["/log/rotate"] = x => { return GetRotateLogs(); };
             Get["/log/rotate/start"] = x => { return StartRotateLogs(); };
+
+            // 20. Dev
+#if DEBUG
+            Get["/dev/contracts/{entity?}"] = x => { return ExtractContracts((string)x.entity); };
+#endif
         }
 
         JMMServiceImplementationREST _rest = new JMMServiceImplementationREST();
@@ -2097,6 +2104,21 @@ namespace JMMServer.API
             result.Add("position", reader.Position);
             result.Add("lines", logLines.ToArray());
             return result;
+        }
+
+        #endregion
+
+        #region 20. Dev
+
+        /// <summary>
+        /// Dumps the contracts as JSON files embedded in a zip file.
+        /// </summary>
+        /// <param name="entityType">The type of the entity to dump (can be <see cref="string.Empty"/> or <c>null</c> to dump all).</param>
+        private object ExtractContracts(string entityType)
+        {
+            var zipStream = new ContractExtractor().GetContractsAsZipStream(entityType);
+
+            return new StreamResponse(() => zipStream, "application/zip").AsAttachment("contracts.zip");
         }
 
         #endregion

--- a/JMMServer/Entities/AnimeSeries.cs
+++ b/JMMServer/Entities/AnimeSeries.cs
@@ -674,18 +674,14 @@ namespace JMMServer.Entities
                         Contract_AniDBAnime aniDbAnime = contract.AniDBAnime.AniDBAnime;
                         DefaultAnimeImages defImages;
 
-                        if (defImagesByAnime.Value.TryGetValue(animeRec.AnimeID, out defImages))
+                        if (!defImagesByAnime.Value.TryGetValue(animeRec.AnimeID, out defImages))
                         {
-                            aniDbAnime.DefaultImagePoster = defImages.GetPosterContractNoBlanks();
-                            aniDbAnime.DefaultImageFanart = defImages.GetFanartContractNoBlanks(aniDbAnime);
-                            aniDbAnime.DefaultImageWideBanner = defImages.WideBanner?.ToContract();
+                            defImages = new DefaultAnimeImages { AnimeID = animeRec.AnimeID };
                         }
-                        else // No default images found for anime
-                        {
-                            aniDbAnime.DefaultImagePoster = null;
-                            aniDbAnime.DefaultImageFanart = null;
-                            aniDbAnime.DefaultImageWideBanner = null;
-                        }
+
+                        aniDbAnime.DefaultImagePoster = defImages.GetPosterContractNoBlanks();
+                        aniDbAnime.DefaultImageFanart = defImages.GetFanartContractNoBlanks(aniDbAnime);
+                        aniDbAnime.DefaultImageWideBanner = defImages.WideBanner?.ToContract();
                     }
 
                     // TvDB contracts

--- a/JMMServer/JMMServer.csproj
+++ b/JMMServer/JMMServer.csproj
@@ -842,6 +842,7 @@
     <Compile Include="ServerSettings.cs" />
     <Compile Include="ServerState.cs" />
     <Compile Include="SubStream.cs" />
+    <Compile Include="Tasks\ContractExtractor.cs" />
     <Compile Include="TimeUpdater.cs" />
     <Compile Include="UI\AboutForm.xaml.cs">
       <DependentUpon>AboutForm.xaml</DependentUpon>

--- a/JMMServer/Repositories/Cached/AniDB_AnimeRepository.cs
+++ b/JMMServer/Repositories/Cached/AniDB_AnimeRepository.cs
@@ -272,7 +272,7 @@ namespace JMMServer.Repositories
             {
                 return null;
             }
-            else if (fanarts.Count == 1)
+            if (fanarts.Count == 1)
             {
                 return fanarts[0];
             }

--- a/JMMServer/Repositories/ChangeTracker.cs
+++ b/JMMServer/Repositories/ChangeTracker.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using TMDbLib.Objects.Movies;
 
 namespace JMMServer.Repositories
 {
@@ -29,8 +26,7 @@ namespace JMMServer.Repositories
             try
             {
                 Lock();
-                if (_removals.ContainsKey(item))
-                    _removals.Remove(item);
+                _removals.Remove(item);
                 _changes[item] = DateTime.Now;
             }
             finally
@@ -47,8 +43,7 @@ namespace JMMServer.Repositories
                 DateTime dt = DateTime.Now;
                 foreach (T item in range)
                 {
-                    if (_removals.ContainsKey(item))
-                        _removals.Remove(item);
+                    _removals.Remove(item);
                     _changes[item] = dt;
                 }
             }
@@ -64,10 +59,30 @@ namespace JMMServer.Repositories
             try
             {
                 Lock();
-                if (_changes.ContainsKey(item))
+                if (_changes.Remove(item))
                 {
-                    _changes.Remove(item);
                     _removals[item] = DateTime.Now;
+                }
+            }
+            finally
+            {
+                Unlock();
+            }
+        }
+
+        public void RemoveRange(IEnumerable<T> range)
+        {
+            try
+            {
+                Lock();
+                DateTime dt = DateTime.Now;
+
+                foreach (T item in range)
+                {
+                    if (_changes.Remove(item))
+                    {
+                        _removals[item] = dt;
+                    }
                 }
             }
             finally

--- a/JMMServer/Repositories/NHibernate/ISessionWrapper.cs
+++ b/JMMServer/Repositories/NHibernate/ISessionWrapper.cs
@@ -14,6 +14,8 @@ namespace JMMServer.Repositories.NHibernate
 
         ISQLQuery CreateSQLQuery(string query);
 
+        IQueryOver<T, T> QueryOver<T>() where T : class;
+
         TObj Get<TObj>(object id);
 
         ITransaction BeginTransaction();

--- a/JMMServer/Repositories/NHibernate/SessionWrapper.cs
+++ b/JMMServer/Repositories/NHibernate/SessionWrapper.cs
@@ -38,6 +38,11 @@ namespace JMMServer.Repositories.NHibernate
             return _session.CreateSQLQuery(query);
         }
 
+        public IQueryOver<T, T> QueryOver<T>() where T : class
+        {
+            return _session.QueryOver<T>();
+        }
+
         public TObj Get<TObj>(object id)
         {
             return _session.Get<TObj>(id);

--- a/JMMServer/Repositories/NHibernate/StatelessSessionWrapper.cs
+++ b/JMMServer/Repositories/NHibernate/StatelessSessionWrapper.cs
@@ -38,6 +38,11 @@ namespace JMMServer.Repositories.NHibernate
             return _session.CreateSQLQuery(query);
         }
 
+        public IQueryOver<T, T> QueryOver<T>() where T : class
+        {
+            return _session.QueryOver<T>();
+        }
+
         public TObj Get<TObj>(object id)
         {
             return _session.Get<TObj>(id);

--- a/JMMServer/Tasks/ContractExtractor.cs
+++ b/JMMServer/Tasks/ContractExtractor.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using JMMContracts;
+using JMMContracts.PlexAndKodi;
+using JMMServer.Databases;
+using JMMServer.Entities;
+using JMMServer.LZ4;
+using JMMServer.Repositories.NHibernate;
+using Newtonsoft.Json;
+using NHibernate;
+using NHibernate.Criterion;
+using NHibernate.Criterion.Lambda;
+
+namespace JMMServer.Tasks
+{
+    internal class ContractExtractor
+    {
+        private static Dictionary<string, Action<ISessionWrapper, ZipArchive>> ContractExtractors =
+            new Dictionary<string, Action<ISessionWrapper, ZipArchive>>(StringComparer.OrdinalIgnoreCase);
+
+        static ContractExtractor()
+        {
+            ContractExtractors.Add("AniDB_Anime", (sw, za) =>
+                {
+                    ExtractContracts<AniDB_Anime, Contract_AniDB_AnimeDetailed>(sw, za, pb =>
+                        {
+                            pb.Select(CreateEntryNameProjection<AniDB_Anime>("AniDB_Anime\\a", a => a.AnimeID));
+                            pb.Select(s => s.ContractSize);
+                            pb.Select(s => s.ContractBlob);
+                            return pb;
+                        });
+                });
+            ContractExtractors.Add("AnimeEpisode", (sw, za) =>
+                {
+                    ExtractContracts<AnimeEpisode, Video>(sw, za, pb =>
+                        {
+                            pb.Select(CreateEntryNameProjection<AnimeEpisode>("AnimeEpisode\\s", a => a.AnimeSeriesID, "_e", a => a.AnimeEpisodeID));
+                            pb.Select(s => s.PlexContractSize);
+                            pb.Select(s => s.PlexContractBlob);
+                            return pb;
+                        });
+                });
+            ContractExtractors.Add("AnimeEpisode_User", (sw, za) =>
+                {
+                    ExtractContracts<AnimeEpisode_User, Contract_AnimeEpisode>(sw, za, pb =>
+                        {
+                            pb.Select(CreateEntryNameProjection<AnimeEpisode_User>("AnimeEpisode_User\\u", a => a.JMMUserID,
+                                "\\s", a => a.AnimeSeriesID, "_e", a => a.AnimeEpisodeID));
+                            pb.Select(s => s.ContractSize);
+                            pb.Select(s => s.ContractBlob);
+                            return pb;
+                        });
+                });
+            ContractExtractors.Add("AnimeGroup", (sw, za) =>
+                {
+                    ExtractContracts<AnimeGroup, Contract_AnimeGroup>(sw, za, pb =>
+                        {
+                            pb.Select(CreateEntryNameProjection<AnimeGroup>("AnimeGroup\\g", a => a.AnimeGroupID));
+                            pb.Select(s => s.ContractSize);
+                            pb.Select(s => s.ContractBlob);
+                            return pb;
+                        });
+                });
+            ContractExtractors.Add("AnimeGroup_User", (sw, za) =>
+                {
+                    ExtractContracts<AnimeGroup_User, Video>(sw, za, pb =>
+                        {
+                            pb.Select(CreateEntryNameProjection<AnimeGroup_User>("AnimeGroup_User\\u", a => a.JMMUserID, "\\g", a => a.AnimeGroupID));
+                            pb.Select(s => s.PlexContractSize);
+                            pb.Select(s => s.PlexContractBlob);
+                            return pb;
+                        });
+                });
+            ContractExtractors.Add("AnimeSeries", (sw, za) =>
+                {
+                    ExtractContracts<AnimeSeries, Contract_AnimeSeries>(sw, za, pb =>
+                        {
+                            pb.Select(CreateEntryNameProjection<AnimeSeries>("AnimeSeries\\g", a => a.AnimeGroupID, "_s", a => a.AnimeSeriesID));
+                            pb.Select(s => s.ContractSize);
+                            pb.Select(s => s.ContractBlob);
+                            return pb;
+                        });
+                });
+            ContractExtractors.Add("AnimeSeries_User", (sw, za) =>
+                {
+                    ExtractContracts<AnimeSeries_User, Video>(sw, za, pb =>
+                        {
+                            pb.Select(CreateEntryNameProjection<AnimeSeries_User>("AnimeSeries_User\\u", a => a.JMMUserID, "\\s", a => a.AnimeSeriesID));
+                            pb.Select(s => s.PlexContractSize);
+                            pb.Select(s => s.PlexContractBlob);
+                            return pb;
+                        });
+                });
+        }
+
+        private static IProjection CreateEntryNameProjection<T>(string prefix, Expression<Func<T, object>> keyCol)
+        {
+            return Projections.SqlFunction("concat", NHibernateUtil.String,
+                Projections.Constant(prefix),
+                Projections.Cast(NHibernateUtil.String, Projections.Property(keyCol)),
+                Projections.Constant(".json"));
+        }
+
+        private static IProjection CreateEntryNameProjection<T>(string prefix1, Expression<Func<T, object>> keyCol1,
+            string prefix2, Expression<Func<T, object>> keyCol2)
+        {
+            return Projections.SqlFunction("concat", NHibernateUtil.String,
+                Projections.Constant(prefix1),
+                Projections.Cast(NHibernateUtil.String, Projections.Property(keyCol1)),
+                Projections.Constant(prefix2),
+                Projections.Cast(NHibernateUtil.String, Projections.Property(keyCol2)),
+                Projections.Constant(".json"));
+        }
+
+        private static IProjection CreateEntryNameProjection<T>(string prefix1, Expression<Func<T, object>> keyCol1,
+            string prefix2, Expression<Func<T, object>> keyCol2,
+            string prefix3, Expression<Func<T, object>> keyCol3)
+        {
+            return Projections.SqlFunction("concat", NHibernateUtil.String,
+                Projections.Constant(prefix1),
+                Projections.Cast(NHibernateUtil.String, Projections.Property(keyCol1)),
+                Projections.Constant(prefix2),
+                Projections.Cast(NHibernateUtil.String, Projections.Property(keyCol2)),
+                Projections.Constant(prefix3),
+                Projections.Cast(NHibernateUtil.String, Projections.Property(keyCol3)),
+                Projections.Constant(".json"));
+        }
+
+        /// <summary>
+        /// Gets the contracts as embedded json files within a zip archive.
+        /// </summary>
+        /// <param name="entityType">The type of the entity to dump (can be <see cref="string.Empty"/> or <c>null</c> to dump all).</param>
+        /// <returns>The zip archive <see cref="System.IO.Stream"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">The specified <paramref name="entityType"/> is not valid.</exception>
+        public System.IO.Stream GetContractsAsZipStream(string entityType)
+        {
+            using (IStatelessSession session = DatabaseFactory.SessionFactory.OpenStatelessSession())
+            {
+                return GetContractsAsZipStream(session.Wrap(), entityType);
+            }
+        }
+
+        /// <summary>
+        /// Gets the contracts as embedded json files within a zip archive.
+        /// </summary>
+        /// <param name="session">The NHibernate session.</param>
+        /// <param name="entityType">The type of the entity to dump (can be <see cref="string.Empty"/> or <c>null</c> to dump all).</param>
+        /// <returns>The zip archive <see cref="System.IO.Stream"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="session"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">The specified <paramref name="entityType"/> is not valid.</exception>
+        public System.IO.Stream GetContractsAsZipStream(ISessionWrapper session, string entityType)
+        {
+            if (session == null)
+                throw new ArgumentNullException(nameof(session));
+
+            MemoryStream buffer = new MemoryStream();
+
+            using (ZipArchive zip = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                if (String.IsNullOrEmpty(entityType))
+                {   // When no entityType has been specified, we'll just dump everything
+                    foreach (var contractDumpAction in ContractExtractors.Values)
+                    {
+                        contractDumpAction(session, zip);
+                    }
+                }
+                else
+                {
+                    Action<ISessionWrapper, ZipArchive> contractDumpAction;
+
+                    if (ContractExtractors.TryGetValue(entityType, out contractDumpAction))
+                    {
+                        contractDumpAction(session, zip);
+                    }
+                    else
+                    {
+                        throw new ArgumentException("Invalid entityType specified", nameof(entityType));
+                    }
+                }
+            }
+
+            buffer.Position = 0;
+
+            return buffer;
+        }
+
+        private static void ExtractContracts<TEntity, TContract>(ISessionWrapper session, ZipArchive zip,
+            Func<QueryOverProjectionBuilder<TEntity>, QueryOverProjectionBuilder<TEntity>> fieldBuilder)
+            where TEntity : class
+            where TContract : class
+        {
+            var records = session.QueryOver<TEntity>()
+                .SelectList(fieldBuilder)
+                .List<object[]>();
+            var jsonSerializer = new JsonSerializer
+                {
+                    Formatting = Formatting.Indented,
+                    NullValueHandling = NullValueHandling.Include
+                };
+            var zipLock = new object();
+
+            // We should be able to get a bit of a perf boost using parallelism. However, since we're locking on
+            // writing to the zip archive, using any more than 2 threads would be pointless in this case
+            Parallel.ForEach(records, new ParallelOptions { MaxDegreeOfParallelism = 2 }, record =>
+                {
+                    string zipEntryName = record[0].ToString();
+                    int contractLen = (int)record[1];
+                    byte[] contractBinary = (byte[])record[2];
+
+                    if (contractLen > 0 && contractBinary != null)
+                    {
+                        TContract contract = CompressionHelper.DeserializeObject<TContract>(contractBinary, contractLen);
+
+                        lock (zipLock)
+                        {
+                            ZipArchiveEntry archiveEntry = zip.CreateEntry(zipEntryName, CompressionLevel.Optimal);
+
+                            using (StreamWriter writer = new StreamWriter(archiveEntry.Open(), Encoding.UTF8))
+                            {
+                                jsonSerializer.Serialize(writer, contract);
+                            }
+                        }
+                    }
+                });
+        }
+    }
+}


### PR DESCRIPTION
- Kodi images should now be working correctly.
- Deleting all AnimeGroups/AnimeGroup_Users will now be tracked by their change trackers.
- Added dev nancy API for extracting contracts in a readable form (nancy route is only available in DEBUG compiles. Could be put behind a config setting maybe).

(Requires japanesemediamanager/jmmclient#482 to test with JMM Desktop)
(Also: maybe regen of AniDB_Anime and AnimeSeries contracts if it doesn't initially work as expected)