### PR TITLE
Fixes #496 (part 2)

### DIFF
--- a/JMMServer/Databases/MySQL.cs
+++ b/JMMServer/Databases/MySQL.cs
@@ -15,7 +15,7 @@ namespace JMMServer.Databases
     public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
     {
         public string Name { get; } = "MySQL";
-        public int RequiredVersion { get; } = 58;
+        public int RequiredVersion { get; } = 59;
 
 
         private List<DatabaseCommand> createVersionTable = new List<DatabaseCommand>()
@@ -343,7 +343,8 @@ namespace JMMServer.Databases
             new DatabaseCommand(57, 1, "CREATE TABLE `Scan` ( `ScanID` INT NOT NULL AUTO_INCREMENT, `CreationTime` datetime NOT NULL, `ImportFolders` text character set utf8, `Status` int NOT NULL, PRIMARY KEY (`ScanID`) ) ; "),
             new DatabaseCommand(57, 2, "CREATE TABLE `ScanFile` ( `ScanFileID` INT NOT NULL AUTO_INCREMENT, `ScanID` int NOT NULL, `ImportFolderID` int NOT NULL, `VideoLocal_Place_ID` int NOT NULL, `FullName` text character set utf8, `FileSize` bigint NOT NULL, `Status` int NOT NULL, `CheckDate` datetime NULL, `Hash` text character set utf8, `HashResult` text character set utf8 NULL, PRIMARY KEY (`ScanFileID`) ) ; "),
             new DatabaseCommand(57, 3, "ALTER TABLE `ScanFile` ADD  INDEX `UIX_ScanFileStatus` (`ScanID` ASC, `Status` ASC, `CheckDate` ASC) ;"),
-            new DatabaseCommand(58, 1, DatabaseFixes.FixEmptyVideoInfos)
+            new DatabaseCommand(58, 1, DatabaseFixes.FixEmptyVideoInfos),
+            new DatabaseCommand(59, 1, "ALTER TABLE `GroupFilter` ADD INDEX `IX_groupfilter_GroupFilterName` (`GroupFilterName`(250));")
         };
 
         private DatabaseCommand linuxTableVersionsFix = new DatabaseCommand("RENAME TABLE versions TO Versions;");

--- a/JMMServer/Entities/AnimeEpisode.cs
+++ b/JMMServer/Entities/AnimeEpisode.cs
@@ -191,7 +191,7 @@ namespace JMMServer.Entities
 
         private static object _lock = new object();
 
-        public Contract_AnimeEpisode GetUserContract(int userid)
+        public Contract_AnimeEpisode GetUserContract(int userid, ISessionWrapper session = null)
         {
             lock(_lock) //Make it atomic on creation
             { 
@@ -206,7 +206,16 @@ namespace JMMServer.Entities
                 rr.AnimeSeriesID = this.AnimeSeriesID;
                 rr.JMMUserID = userid;
                 rr.WatchedDate = null;
-                RepoFactory.AnimeEpisode_User.Save(rr);
+
+                if (session != null)
+                {
+                    RepoFactory.AnimeEpisode_User.SaveWithOpenTransaction(session, rr);
+                }
+                else
+                {
+                    RepoFactory.AnimeEpisode_User.Save(rr);
+                }
+
                 return rr.Contract;
             }
         }

--- a/JMMServer/Entities/AnimeGroup_User.cs
+++ b/JMMServer/Entities/AnimeGroup_User.cs
@@ -124,13 +124,13 @@ namespace JMMServer.Entities
             }
         }
 
-        public void UpdatePlexKodiContracts()
+        public void UpdatePlexKodiContracts(ISessionWrapper session = null)
         {
             AnimeGroup grp = RepoFactory.AnimeGroup.GetByID(AnimeGroupID);
             if (grp == null)
                 return;
             List<AnimeSeries> series = grp.GetAllSeries();
-            PlexContract = Helper.GenerateFromAnimeGroup(grp, JMMUserID, series);
+            PlexContract = Helper.GenerateFromAnimeGroup(grp, JMMUserID, series, session);
         }
 
         public bool HasUnwatchedFiles => UnwatchedEpisodeCount > 0;

--- a/JMMServer/PlexAndKodi/Helper.cs
+++ b/JMMServer/PlexAndKodi/Helper.cs
@@ -751,7 +751,7 @@ namespace JMMServer.PlexAndKodi
 		    return details.GenArt();
 	    }
 
-        public static Video GenerateFromAnimeGroup(AnimeGroup grp, int userid, List<AnimeSeries> allSeries)
+        public static Video GenerateFromAnimeGroup(AnimeGroup grp, int userid, List<AnimeSeries> allSeries, ISessionWrapper session = null)
         {
             Contract_AnimeGroup cgrp = grp.GetUserContract(userid);
             int subgrpcnt = grp.GetAllChildGroups().Count;
@@ -764,7 +764,7 @@ namespace JMMServer.PlexAndKodi
                     Contract_AnimeSeries cserie = ser.GetUserContract(userid);
                     if (cserie != null)
                     {
-                        Video v = GenerateFromSeries(cserie, ser, ser.GetAnime(), userid);
+                        Video v = GenerateFromSeries(cserie, ser, ser.GetAnime(), userid, session);
 						v.AirDate = ser.AirDate;
                         v.UpdatedAt = ser.LatestEpisodeAirDate.HasValue
                             ? ser.LatestEpisodeAirDate.Value.ToUnixTime()
@@ -929,11 +929,11 @@ namespace JMMServer.PlexAndKodi
         }
 
         public static Video GenerateFromSeries(Contract_AnimeSeries cserie, AnimeSeries ser, AniDB_Anime anidb,
-            int userid)
+            int userid, ISessionWrapper session = null)
         {
             Video v = new Directory();
             Dictionary<AnimeEpisode, Contract_AnimeEpisode> episodes = ser.GetAnimeEpisodes()
-                .ToDictionary(a => a, a => a.GetUserContract(userid));
+                .ToDictionary(a => a, a => a.GetUserContract(userid, session));
             episodes = episodes.Where(a => a.Value == null || a.Value.LocalFileCount > 0)
                 .ToDictionary(a => a.Key, a => a.Value);
             FillSerie(v, ser, episodes, anidb, cserie, userid);

--- a/JMMServer/Repositories/BaseDirectRepository.cs
+++ b/JMMServer/Repositories/BaseDirectRepository.cs
@@ -14,7 +14,7 @@ namespace JMMServer.Repositories
         public Action<ISession, T> DeleteWithOpenTransactionCallback { get; set; }
         public Action<T> EndDeleteCallback { get; set; }
         public Action<T> BeginSaveCallback { get; set; }
-        public Action<ISession, T> SaveWithOpenTransactionCallback { get; set; }
+        public Action<ISessionWrapper, T> SaveWithOpenTransactionCallback { get; set; }
         public Action<T> EndSaveCallback { get; set; }
 
         public virtual T GetByID(S id)
@@ -131,7 +131,7 @@ namespace JMMServer.Repositories
                 using (var transaction = session.BeginTransaction())
                 {
                     session.SaveOrUpdate(obj);
-                    SaveWithOpenTransactionCallback?.Invoke(session, obj);
+                    SaveWithOpenTransactionCallback?.Invoke(session.Wrap(), obj);
                     transaction.Commit();
                 }
             }
@@ -151,7 +151,7 @@ namespace JMMServer.Repositories
                     foreach (T obj in objs)
                     {
                         session.SaveOrUpdate(obj);
-                        SaveWithOpenTransactionCallback?.Invoke(session, obj);
+                        SaveWithOpenTransactionCallback?.Invoke(session.Wrap(), obj);
                     }
                     transaction.Commit();   
                 }
@@ -175,7 +175,7 @@ namespace JMMServer.Repositories
             foreach (T obj in objs)
             {
                 session.SaveOrUpdate(obj);
-                SaveWithOpenTransactionCallback?.Invoke(session, obj);
+                SaveWithOpenTransactionCallback?.Invoke(session.Wrap(), obj);
             }
         }
     }

--- a/JMMServer/Repositories/Cached/AnimeEpisode_UserRepository.cs
+++ b/JMMServer/Repositories/Cached/AnimeEpisode_UserRepository.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using JMMContracts;
 using JMMServer.Entities;
+using JMMServer.Repositories.NHibernate;
 using NHibernate;
 using NutzCode.InMemoryIndex;
 
@@ -85,6 +86,19 @@ namespace JMMServer.Repositories.Cached
             }
         }
 
+        public override void SaveWithOpenTransaction(ISessionWrapper session, AnimeEpisode_User obj)
+        {
+            lock (obj)
+            {
+                if (obj.AnimeEpisode_UserID == 0)
+                {
+                    base.SaveWithOpenTransaction(session, obj);
+
+                }
+                UpdateContract(obj);
+                base.SaveWithOpenTransaction(session, obj);
+            }
+        }
 
         public List<AnimeEpisode_User> GetBySeriesID(int seriesid)
         {

--- a/JMMServer/Repositories/IRepository.cs
+++ b/JMMServer/Repositories/IRepository.cs
@@ -24,7 +24,7 @@ namespace JMMServer.Repositories
         Action<ISession, T> DeleteWithOpenTransactionCallback { get; set; }
         Action<T> EndDeleteCallback { get; set; }
         Action<T> BeginSaveCallback { get; set; }
-        Action<ISession, T> SaveWithOpenTransactionCallback { get; set; }
+        Action<ISessionWrapper, T> SaveWithOpenTransactionCallback { get; set; }
         Action<T> EndSaveCallback { get; set; }
     }
 }

--- a/JMMServer/Tasks/AnimeGroupCreator.cs
+++ b/JMMServer/Tasks/AnimeGroupCreator.cs
@@ -155,8 +155,12 @@ namespace JMMServer.Tasks
             _animeGroupUserRepo.Populate(session, displayname: false);
             _animeGroupRepo.Populate(session, displayname: false);
 
-            // The reason we're doing this in parallel is because updating contacts does a reasonable amount of work (including LZ4 compression)
-            Parallel.ForEach(animeGroupUsers, groupUser => groupUser.UpdatePlexKodiContracts());
+            // NOTE: There are situations in which UpdatePlexKodiContracts will cause database database writes to occur, so we can't
+            // use Parallel.ForEach for the time being (If it was guaranteed to only read then we'd be ok)
+            foreach (AnimeGroup_User groupUser in animeGroupUsers)
+            {
+                groupUser.UpdatePlexKodiContracts(session);
+            }
 
             _animeGroupUserRepo.UpdateBatch(session, animeGroupUsers);
             _log.Info("AnimeGroup_Users have been created");


### PR DESCRIPTION
- Added prefix index (250 chars) on GroupFilter.GroupFilterName for MySQL (SQL Server and SQLite seem fine without that particular index for the time being). It didn't seem to require the Anidb_tag.TagName index as mentioned [here](https://github.com/japanesemediamanager/jmmserver/issues/496#issuecomment-257081164).
- Removed Parallelism from updating Plex/Kodi contracts when Recreating All Groups. There was a possible situation that would cause Plex/Kodi contract construction code to end up creating new database records (I think this is probably because I was inserting a heap of AnimeSeries to test with which resulted in missing User records, etc.). This also required passing the session through to the culprit in question so that it would partake in an existing transaction.

I've tested all 3 supported databases with 2631 AnimeSeries in each database. The results for me are now:

Database | Duration
--- | ---:
MS SQL Server 2014 | 17s
SQLite | 18s
MySQL 5.7 | 41s

I'm not sure why MySQL is a lot slower than the other two. But at least from my testing, it successfuly completes the Recreate All Groups process when it involves a fair number of series.